### PR TITLE
Add EXIT_ON_CRASH option to ZestGuidance and maven plugin

### DIFF
--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
@@ -195,6 +195,9 @@ public class ZestGuidance implements Guidance {
     /** Number of conditional jumps since last run was started. */
     protected long branchCount;
 
+    /** Whether to stop/exit once a crash is found. **/
+    static final boolean EXIT_ON_CRASH = Boolean.getBoolean("jqf.ei.EXIT_ON_CRASH");
+
     // ------------- FUZZING HEURISTICS ------------
 
     /** Whether to save only valid inputs **/
@@ -566,6 +569,10 @@ public class ZestGuidance implements Guidance {
     public boolean hasInput() {
         Date now = new Date();
         long elapsedMilliseconds = now.getTime() - startTime.getTime();
+        if (EXIT_ON_CRASH && uniqueFailures.size() >= 1) {
+            // exit
+            return false;
+        }
         return elapsedMilliseconds < maxDurationMillis;
     }
 

--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
@@ -155,6 +155,16 @@ public class FuzzGoal extends AbstractMojo {
     @Parameter(property="out")
     private String outputDirectory;
 
+    /**
+     * Whether to stop fuzzing once a crash is found.
+     *
+     * <p>If this property is set to <tt>true</tt>, then the fuzzing
+     * will exit on first crash. Useful for continuous fuzzing when you dont wont to consume resource
+     * once a crash is found. Also fuzzing will be more effective once the crash is fixed.</p>
+     */
+    @Parameter(property="exitOnCrash")
+    private String exitOnCrash;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         ClassLoader loader;
@@ -169,6 +179,11 @@ public class FuzzGoal extends AbstractMojo {
         }
         if (includes != null) {
             System.setProperty("janala.includes", includes);
+        }
+
+        // Configure Zest Guidance
+        if (exitOnCrash != null) {
+            System.setProperty("jqf.ei.EXIT_ON_CRASH", exitOnCrash);
         }
 
         Duration duration = null;


### PR DESCRIPTION
Hey @rohanpadhye,

This is a small feature that adds an option to exit once first crash is encountered. This is useful for continuous fuzzing as well as usually once you fix the crashes you encounter you get better fuzzing results as the fuzzer is not "stuck" in the same crash path.

please review:)

Thanks!