### PR TITLE
Repro: Optionally print generated args before running test case

### DIFF
--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/guidance/Guidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/guidance/Guidance.java
@@ -109,6 +109,27 @@ public interface Guidance {
     boolean hasInput();
 
     /**
+     * Callback for observing actual arguments passed to the test method.
+     *
+     * <p>This method is invoked exactly once after each call to
+     * {@link #getInput()}. The arguments to this callback are
+     * the structured inputs that are produced by junit-quickcheck
+     * generators, which in turn decode the bytes produced by
+     * {@link #getInput()}.</p>
+     *
+     * <p>This method is useful for logging the generated args or for
+     * calculating the size of the generated args. The default implementation
+     * does nothing.</p>
+     *
+     * @param args an array of arguments that will be passed to the test
+     *             method; the size of this array is equal to the number of
+     *             formal parameters to the test method
+     */
+    default void observeGeneratedArgs(Object[] args) {
+        // Do nothing
+    }
+
+    /**
      * Handles the end of a fuzzing trial.
      *
      * <p>This method is guaranteed to be invoked by JQF

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
@@ -139,6 +139,9 @@ public class FuzzStatement extends Statement {
                         args = generators.stream()
                                 .map(g -> g.generate(random, genStatus))
                                 .toArray();
+
+                        // Let guidance observe the generated input args
+                        guidance.observeGeneratedArgs(args);
                     } catch (IllegalStateException e) {
                         if (e.getCause() instanceof EOFException) {
                             // This happens when we reach EOF before reading all the random values.

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/repro/ReproGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/repro/ReproGuidance.java
@@ -78,6 +78,7 @@ public class ReproGuidance implements Guidance {
     private Set<String> branchesCoveredInCurrentRun;
     private Set<String> allBranchesCovered;
     private boolean ignoreInvalidCoverage;
+    private boolean printArgs;
 
     HashMap<Integer, String> branchDescCache = new HashMap<>();
 
@@ -99,8 +100,8 @@ public class ReproGuidance implements Guidance {
             allBranchesCovered = new HashSet<>();
             branchesCoveredInCurrentRun = new HashSet<>();
             ignoreInvalidCoverage = Boolean.getBoolean("jqf.repro.ignoreInvalidCoverage");
-
         }
+        printArgs = Boolean.getBoolean("jqf.repro.printArgs");
     }
 
     /**
@@ -147,6 +148,16 @@ public class ReproGuidance implements Guidance {
         return nextFileIdx < inputFiles.length;
     }
 
+    @Override
+    public void observeGeneratedArgs(Object[] args) {
+        if (printArgs) {
+            String inputFileName = getCurrentInputFile().getName();
+            for (int i = 0; i < args.length; i++) {
+                System.out.printf("%s[%d]: %s\n", inputFileName, i, String.valueOf(args[i]));
+            }
+        }
+    }
+
     /**
      * Returns the input file which is currently being repro'd.
      * @return the current input file
@@ -175,9 +186,9 @@ public class ReproGuidance implements Guidance {
         // Print result
         File inputFile = getCurrentInputFile();
         if (result == Result.FAILURE) {
-            System.out.printf("%s: %s (%s)\n", inputFile.getName(), result, error.getClass().getName());
+            System.out.printf("%s ::= %s (%s)\n", inputFile.getName(), result, error.getClass().getName());
         } else {
-            System.out.printf("%s: %s\n", inputFile.getName(), result);
+            System.out.printf("%s ::= %s\n", inputFile.getName(), result);
         }
 
         // Possibly accumulate coverage

--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/ReproGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/ReproGoal.java
@@ -138,6 +138,22 @@ public class ReproGoal extends AbstractMojo {
     @Parameter(property="includes")
     private String includes;
 
+    /**
+     * Whether to print the args to each test case.
+     *
+     * <p>The input file being repro'd is usually a sequence of bytes
+     * that is decoded by the junit-quickcheck generators corresponding
+     * to the parameters declared in the test method. Unless the test method
+     * contains just one arg of type InputStream, the input file itself
+     * does not directly correspond to the args sent to the test method.</p>
+     *
+     * <p>If this file is set, then the args decoded from a repro'd input
+     * file are first printed to standard output before invoking the test
+     * method.</p>
+     */
+    @Parameter(property="printArgs")
+    private boolean printArgs;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         ClassLoader loader;
@@ -167,6 +183,11 @@ public class ReproGoal extends AbstractMojo {
         // If a coverage dump file was provided, enable logging via system property
         if (logCoverage != null) {
             System.setProperty("jqf.repro.logUniqueBranches", "true");
+        }
+
+        // If args should be printed, set system property
+        if (printArgs) {
+            System.setProperty("jqf.repro.printArgs", "true");
         }
 
         File inputFile = new File(input);


### PR DESCRIPTION
Enables the flag `-DprintArgs` as follows:

```
mvn jqf:repro -Dclass=<class> -Dmethod=<method> -Dinput=<file> -DprintArgs
```

If set, the args to the test case are printed to screen before running the test case. This is useful when using structured input generators, because the input file itself is a meaningless sequence of bytes. 

For command-line usage of `bin/jqf-repro`, the system property `jqf.repro.printArgs` must be set to `true`.