### PR TITLE
Add Trophies to README so people can easily add them via PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ JQF is a modular framework, supporting the following pluggable fuzzing front-end
 * Semantic fuzzing with **[Zest](http://arxiv.org/abs/1812.00078)** [[ISSTA'19 paper](https://cs.berkeley.edu/~rohanpadhye/files/zest-issta19.pdf)] ([tutorial 1](https://github.com/rohanpadhye/jqf/wiki/Fuzzing-with-Zest)) ([tutorial 2](https://github.com/rohanpadhye/jqf/wiki/Fuzzing-a-Compiler))
 * Complexity fuzzing with **[PerfFuzz](https://github.com/carolemieux/perffuzz)** [[ISSTA'18 paper](https://people.eecs.berkeley.edu/~rohanpadhye/files/perffuzz-issta18.pdf)]
 
-JQF has been successful in [discovering a number of bugs in widely used open-source software](https://github.com/rohanpadhye/jqf/wiki/Bug-trophy-case) such as OpenJDK, Apache Maven and the Google Closure Compiler.
+JQF has been successful in [discovering a number of bugs in widely used open-source software](#trophies) such as OpenJDK, Apache Maven and the Google Closure Compiler.
 
 ### Tool paper
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ JQF supports the **[*Zest algorithm*](https://cs.berkeley.edu/~rohanpadhye/files
 The [JQF wiki](https://github.com/rohanpadhye/jqf/wiki) contains lots more documentation including:
 - [Using a custom fuzz guidance](https://github.com/rohanpadhye/jqf/wiki/The-Guidance-interface)
 - [Performance Benchmarks](https://github.com/rohanpadhye/jqf/wiki/Performance-benchmarks)
-- [Bug trophy case](https://github.com/rohanpadhye/jqf/wiki/Bug-trophy-case)
 
 JQF also publishes its [API docs](https://rohanpadhye.github.io/jqf/apidocs).
 
@@ -61,3 +60,51 @@ We want your feedback! (haha, get it? get it?)
 If you've found a bug in JQF or are having trouble getting JQF to work, please open an issue on the [issue tracker](https://github.com/rohanpadhye/jqf/issues). You can also use this platform to post feature requests.
 
 If it's some sort of fuzzing emergency you can always send an email to the main developer: [Rohan Padhye](https://people.eecs.berkeley.edu/~rohanpadhye).
+
+## Trophies
+
+If you find bugs with JQF and you comfortable with sharing, We would be happy to add them to this list. 
+Please send a PR for README.md with a link to the bug/cve you found.
+
+- [google/closure-compiler#2842](https://github.com/google/closure-compiler/issues/2842): IllegalStateException in VarCheck: Unexpected variable
+- [google/closure-compiler#2843](https://github.com/google/closure-compiler/issues/2843): NullPointerException when using Arrow Functions in dead code 
+- [google/closure-compiler#3173](https://github.com/google/closure-compiler/issues/3173): Algorithmic complexity / performance issue on fuzzed input
+- [google/closure-compiler#3220](https://github.com/google/closure-compiler/issues/3220): ExpressionDecomposer throws IllegalStateException: Object method calls can not be decomposed
+- [JDK-8190332](https://bugs.openjdk.java.net/browse/JDK-8190332): PngReader throws NegativeArraySizeException when width is too large
+- [JDK-8190511](https://bugs.openjdk.java.net/browse/JDK-8190511): PngReader throws OutOfMemoryError for very small malformed PNGs
+- [JDK-8190512](https://bugs.openjdk.java.net/browse/JDK-8190512): PngReader throws undocumented IllegalArgumentException: "Empty Region" instead of IOException for malformed images with negative dimensions
+- [JDK-8190997](https://bugs.openjdk.java.net/browse/JDK-8190997): PngReader throws NullPointerException when PLTE section is missing
+- [JDK-8191023](https://bugs.openjdk.java.net/browse/JDK-8191023): PngReader throws NegativeArraySizeException in parse_tEXt_chunk when keyword length exceeeds chunk size
+- [JDK-8191076](https://bugs.openjdk.java.net/browse/JDK-8191076): PngReader throws  NegativeArraySizeException in parse_zTXt_chunk when keyword length exceeds chunk size
+- [JDK-8191109](https://bugs.openjdk.java.net/browse/JDK-8191109): PngReader throws NegativeArraySizeException in parse_iCCP_chunk when keyword length exceeds chunk size
+- [JDK-8191174](https://bugs.openjdk.java.net/browse/JDK-8191174): PngReader throws undocumented llegalArgumentException with message "Pixel stride times width must be <= scanline stride"
+- [JDK-8191073](https://bugs.openjdk.java.net/browse/JDK-8191073): JpegImageReader throws IndexOutOfBoundsException when reading malformed header
+- [JDK-8193444](https://bugs.openjdk.java.net/browse/JDK-8193444): SimpleDateFormat throws ArrayIndexOutOfBoundsException when format contains long sequences of unicode characters
+- [JDK-8193877](https://bugs.openjdk.java.net/browse/JDK-8193877): DateTimeFormatterBuilder throws ClassCastException when using padding
+- [mozilla/rhino#405](https://github.com/mozilla/rhino/issues/405): FAILED ASSERTION due to malformed destructuring syntax
+- [mozilla/rhino#406](https://github.com/mozilla/rhino/issues/406): ClassCastException when compiling malformed destructuring expression
+- [mozilla/rhino#407](https://github.com/mozilla/rhino/issues/407): java.lang.VerifyError in bytecode produced by CodeGen
+- [mozilla/rhino#409](https://github.com/mozilla/rhino/issues/409): ArrayIndexOutOfBoundsException when parsing '<!-'
+- [mozilla/rhino#410](https://github.com/mozilla/rhino/issues/410): NullPointerException in BodyCodeGen
+- [COLLECTIONS-714](https://issues.apache.org/jira/browse/COLLECTIONS-714): PatriciaTrie ignores trailing null characters in keys
+- [COMPRESS-424](https://issues.apache.org/jira/browse/COMPRESS-424): BZip2CompressorInputStream throws ArrayIndexOutOfBoundsException(s) when decompressing malformed input
+- [LANG-1385](https://issues.apache.org/jira/browse/LANG-1385): StringIndexOutOfBoundsException in NumberUtils.createNumber
+- [**CVE-2018-11771**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11771): Infinite Loop in Commons-Compress ZipArchiveInputStream ([found by Tobias Ospelt](https://modzero.ch/modlog/archives/2018/09/20/java_bugs_with_and_without_fuzzing/index.html))
+- [MNG-6375](https://issues.apache.org/jira/browse/MNG-6375) / [plexus-utils#34](https://github.com/codehaus-plexus/plexus-utils/issues/34): NullPointerException when pom.xml has incomplete XML tag
+- [MNG-6374](https://issues.apache.org/jira/browse/MNG-6374) / [plexus-utils#35](https://github.com/codehaus-plexus/plexus-utils/issues/35): ModelBuilder hangs with malformed pom.xml
+- [MNG-6577](https://issues.apache.org/jira/browse/MNG-6577) / [plexus-utils#57](https://github.com/codehaus-plexus/plexus-utils/issues/57): Uncaught IllegalArgumentException when parsing unicode entity ref
+- [Bug 62655](https://bz.apache.org/bugzilla/show_bug.cgi?id=62655): Augment task: IllegalStateException when "id" attribute is missing 
+- [BCEL-303](https://issues.apache.org/jira/browse/BCEL-303): AssertionViolatedException in Pass 3A Verification of invoke instructions
+- [BCEL-307](https://issues.apache.org/jira/browse/BCEL-307): ClassFormatException thrown in Pass 3A verification
+- [BCEL-308](https://issues.apache.org/jira/browse/BCEL-308): NullPointerException in Verifier Pass 3A
+- [BCEL-309](https://issues.apache.org/jira/browse/BCEL-309): NegativeArraySizeException when Code attribute length is negative
+- [BCEL-310](https://issues.apache.org/jira/browse/BCEL-310): ArrayIndexOutOfBounds in Verifier Pass 3A
+- [BCEL-311](https://issues.apache.org/jira/browse/BCEL-311): ClassCastException in Verifier Pass 2
+- [BCEL-312](https://issues.apache.org/jira/browse/BCEL-312): AssertionViolation: INTERNAL ERROR Please adapt StringRepresentation to deal with ConstantPackage in Verifier Pass 2
+- [BCEL-313](https://issues.apache.org/jira/browse/BCEL-313): ClassFormatException: Invalid signature: Ljava/lang/String)V in Verifier Pass 3A
+- [**CVE-2018-8036**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8036): Infinite Loop leading to OOM in PDFBox's AFMParser ([found by Tobias Ospelt](https://modzero.ch/modlog/archives/2018/09/20/java_bugs_with_and_without_fuzzing/index.html))
+- [PDFBOX-4333](https://issues.apache.org/jira/browse/PDFBOX-4333): ClassCastException when loading PDF (found by Robin Schimpf)
+- [PDFBOX-4338](https://issues.apache.org/jira/browse/PDFBOX-4338): ArrayIndexOutOfBoundsException in COSParser (found by Robin Schimpf)
+- [PDFBOX-4339](https://issues.apache.org/jira/browse/PDFBOX-4339): NullPointerException in COSParser (found by Robin Schimpf)
+- [**CVE-2018-8017**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-8017): Infinite Loop in IptcAnpaParser 
+- [**CVE-2018-12418**](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12418): Infinite Loop in junrar ([found by Tobias Ospelt](https://modzero.ch/modlog/archives/2018/09/20/java_bugs_with_and_without_fuzzing/index.html))


### PR DESCRIPTION
I think one of the most important things for quicker adoption is how many bugs it found so I think
it would be better to add them straight to the readme and this way people can easily add more bugs via PRs unlike the wiki which you can't open a PR to.

I took some inspiration from [go-fuzz](https://github.com/dvyukov/go-fuzz#trophies) README which is quite popular.