### PR TITLE
New ZestCLI (previously: "don't delete corpus on start")

### DIFF
--- a/fuzz/pom.xml
+++ b/fuzz/pom.xml
@@ -21,11 +21,11 @@
         </dependency>
         <dependency>
             <groupId>com.pholser</groupId>
-            <artifactId>junit-quickcheck-core</artifactId>
+            <artifactId>junit-quickcheck-generators</artifactId>
         </dependency>
         <dependency>
             <groupId>com.pholser</groupId>
-            <artifactId>junit-quickcheck-generators</artifactId>
+            <artifactId>junit-quickcheck-core</artifactId>
         </dependency>
         <dependency>
             <groupId>edu.berkeley.cs.jqf</groupId>
@@ -45,6 +45,11 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.picocli</groupId>
+            <artifactId>picocli</artifactId>
+            <version>4.0.4</version>
         </dependency>
     </dependencies>
 
@@ -84,6 +89,31 @@
 		                </execution> 
 		        </executions> 
 			</plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <mainClass>edu.berkeley.cs.jqf.fuzz.ei.ZestCLI</mainClass>
+                                </manifest>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/fuzz/src/main/assembly/assembly.xml
+++ b/fuzz/src/main/assembly/assembly.xml
@@ -1,0 +1,17 @@
+<assembly
+        xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>zest-cli</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestCLI.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestCLI.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2017-2018 The Regents of the University of California
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+package edu.berkeley.cs.jqf.fuzz.ei;
+
+import edu.berkeley.cs.jqf.fuzz.junit.GuidedFuzzing;
+import edu.berkeley.cs.jqf.instrument.InstrumentingClassLoader;
+import org.junit.runner.Result;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+import java.io.File;
+import java.util.ArrayList;
+
+/**
+ * CLI for Zest based guidance.
+ *
+ * @author Yevgeny Pats
+ */
+@CommandLine.Command(name = "ZestCLI", mixinStandardHelpOptions = true, version = "1.3")
+public class ZestCLI implements Runnable{
+    @Option(names = { "-e", "--exit-on-crash" },
+            description = "Exit fuzzer on first crash (default: false)")
+    private boolean exitOnCrash = false;
+
+    @Option(names = { "-l", "--libfuzzer-compat-output" },
+            description = "Use libFuzzer compat output instead of AFL like stats screen (default: false)")
+    private boolean libFuzzerCompatOutput = false;
+
+    @Option(names = { "-i", "--input" },
+            description = "Input directory containing seed test cases (default: none)")
+    private File inputDirectory;
+
+    @Option(names = { "-o", "--output" },
+            description = "Output Directory containing results (default: fuzz_results)")
+    private File outputDirectory = new File("fuzz-results");
+
+    @Parameters(index="0", paramLabel = "PACKAGE", description = "package containing the fuzzer and all dependencies")
+    private String testPackageName;
+
+    @Parameters(index="1", paramLabel = "TEST_CLASS", description = "full class name where the fuzz function is located")
+    private String testClassName;
+
+    @Parameters(index="2", paramLabel = "TEST_METHOD", description = "fuzz function name")
+    private String testMethodName;
+
+
+    private File[] readSeedFiles() {
+        if (this.inputDirectory == null) {
+            return new File[0];
+        }
+
+        ArrayList<File> seedFilesArray = new ArrayList<>();
+        File[] allFiles = this.inputDirectory.listFiles();
+        for (int i = 0; i < allFiles.length; i++) {
+            if (allFiles[i].isFile()) {
+                seedFilesArray.add(allFiles[i]);
+            }
+        }
+        File[] seedFiles = seedFilesArray.toArray(new File[seedFilesArray.size()]);
+        return seedFiles;
+    }
+
+    public void run() {
+
+        File[] seedFiles = readSeedFiles();
+
+        if (this.exitOnCrash) {
+            System.setProperty("jqf.ei.EXIT_ON_CRASH", "true");
+        }
+
+        if (this.libFuzzerCompatOutput) {
+            System.setProperty("jqf.ei.LIBFUZZER_COMPAT_OUTPUT", "true");
+        }
+
+        try {
+            ClassLoader loader = new InstrumentingClassLoader(
+                    new String[]{System.getProperty("java.class.path"), this.testPackageName},
+                    ZestCLI.class.getClassLoader());
+
+            // Load the guidance
+            String title = this.testClassName+"#"+this.testMethodName;
+            ZestGuidance guidance = seedFiles.length > 0 ?
+                    new ZestGuidance(title, null, this.outputDirectory, seedFiles) :
+                    new ZestGuidance(title, null, this.outputDirectory);
+
+            // Run the Junit test
+            Result res = GuidedFuzzing.run(testClassName, testMethodName, loader, guidance, System.out);
+            if (Boolean.getBoolean("jqf.logCoverage")) {
+                System.out.println(String.format("Covered %d edges.",
+                        guidance.getTotalCoverage().getNonZeroCount()));
+            }
+            if (Boolean.getBoolean("jqf.ei.EXIT_ON_CRASH") && !res.wasSuccessful()) {
+                System.exit(3);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.exit(2);
+        }
+
+    }
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new ZestCLI()).execute(args);
+        System.exit(exitCode);
+    }
+}


### PR DESCRIPTION
So isn't that should be the default behaviour of not deleting the corpus on start?

I mean this way it will resume from the same place i.e will take random input from the corpus and mutate and continue?

maybe just throw a warning that the corpus directory is not empty and the fuzzing will continue from this corpus directory?