### PR TITLE
Fix confusing property name which results incorrect help message

### DIFF
--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
@@ -77,7 +77,7 @@ public class FuzzGoal extends AbstractMojo {
      * <p>This class will be loaded using the Maven project's test
      * classpath. It must be annotated with {@code @RunWith(JQF.class)}</p>
      */
-    @Parameter(property="class", required=true)
+    @Parameter(property="testClassName", required=true)
     private String testClassName;
 
     /**
@@ -91,7 +91,7 @@ public class FuzzGoal extends AbstractMojo {
      * test class or if the method is not declared
      * {@code public void}, then the fuzzer will not launch.</p>
      */
-    @Parameter(property="method", required=true)
+    @Parameter(property="testMethod", required=true)
     private String testMethod;
 
     /**


### PR DESCRIPTION
when running maven plugin with `mvn jqf:fuzz` there will be the following message:

```
] Failed to execute goal edu.berkeley.cs.jqf:jqf-maven-plugin:1.4-SNAPSHOT:fuzz (default-cli) on project jqf-examples: The parameters 'testClassName', 'testMethod' for goal edu.berkeley.cs.jqf:jqf-maven-plugin:1.4-SNAPSHOT:fuzz are missing or invalid -> [Help 1]
```

which is incorrect as currently maven expects `-Dclass` and ` -Dmethod`