### PR TITLE
Fix error message: setup.sh is now in top-level directory

### DIFF
--- a/bin/jqf-afl-cmin
+++ b/bin/jqf-afl-cmin
@@ -35,7 +35,7 @@ fi
 
 # Ensure that AFL proxy is built
 if [ ! -f "$ROOT_DIR/bin/afl-proxy" ]; then
-  echo "The JQF-AFL proxy has not been built! Make sure to run scripts/setup.sh or run 'make'" >&2
+  echo "The JQF-AFL proxy has not been built! Make sure to run ./setup.sh or run 'make'" >&2
   exit 3
 fi
 

--- a/bin/jqf-afl-cmin-py
+++ b/bin/jqf-afl-cmin-py
@@ -35,7 +35,7 @@ fi
 
 # Ensure that AFL proxy is built
 if [ ! -f "$ROOT_DIR/bin/afl-proxy" ]; then
-  echo "The JQF-AFL proxy has not been built! Make sure to run scripts/setup.sh or run 'make'" >&2
+  echo "The JQF-AFL proxy has not been built! Make sure to run ./setup.sh or run 'make'" >&2
   exit 3
 fi
 

--- a/bin/jqf-afl-fuzz
+++ b/bin/jqf-afl-fuzz
@@ -39,7 +39,7 @@ fi
 
 # Ensure that AFL proxy is built
 if [ ! -f "$ROOT_DIR/bin/afl-proxy" ]; then
-  echo "The JQF-AFL proxy has not been built! Make sure to run scripts/setup.sh or run 'make'" >&2
+  echo "The JQF-AFL proxy has not been built! Make sure to run ./setup.sh or run 'make'" >&2
   exit 3
 fi
 

--- a/bin/jqf-afl-showmap
+++ b/bin/jqf-afl-showmap
@@ -21,7 +21,7 @@ print_usage() {
 
 # Ensure that AFL proxy is built
 if [ ! -f "$ROOT_DIR/bin/afl-proxy" ]; then
-  echo "The JQF-AFL proxy has not been built! Make sure to run scripts/setup.sh or run 'make'" >&2
+  echo "The JQF-AFL proxy has not been built! Make sure to run ./setup.sh or run 'make'" >&2
   exit 3
 fi
 

--- a/bin/jqf-afl-target
+++ b/bin/jqf-afl-target
@@ -9,7 +9,7 @@ ROOT_DIR=`dirname $BIN_DIR`
 
 # Ensure that proxy is built
 if [ ! -f "$ROOT_DIR/bin/afl-proxy" ]; then
-  echo "The AFL proxy is not built! Make sure to run scripts/setup.sh or run 'make' in afl/" >&2
+  echo "The AFL proxy is not built! Make sure to run ./setup.sh or run 'make' in afl/" >&2
   exit 2
 fi
 


### PR DESCRIPTION
Minor fix in error printout of `jqf-afl-X` scripts to account for the fact that `setup.sh` is no longer in `scripts`.