### PR TITLE
Added null check to SnoopInstructionTransformer.transform to prevent unnecessary NPES

### DIFF
--- a/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
+++ b/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
@@ -22,7 +22,7 @@ public class SnoopInstructionTransformer implements ClassFileTransformer {
   private static final boolean verbose = Config.instance.verbose;
   
   private static String[] banned = {"[", "java/lang", "janala", "org/objectweb/asm", "sun", "jdk", "java/util/function"};
-  private static String[] excludes = Config.instance.excludeInst;;
+  private static String[] excludes = Config.instance.excludeInst;
   private static String[] includes = Config.instance.includeInst;
   
   public static void premain(String agentArgs, Instrumentation inst) throws ClassNotFoundException {
@@ -62,7 +62,7 @@ public class SnoopInstructionTransformer implements ClassFileTransformer {
     Class.forName("java.util.jar.JarFile");
   }
 
-  /** packages that should be exluded from the instrumentation */
+  /** packages that should be excluded from the instrumentation */
   private static boolean shouldExclude(String cname) {
     for (String e : banned) {
       if (cname.startsWith(e)) {
@@ -89,6 +89,10 @@ public class SnoopInstructionTransformer implements ClassFileTransformer {
       ProtectionDomain d, byte[] cbuf)
     throws IllegalClassFormatException {
 
+    if(cname == null) {
+      // Do not instrument lambdas
+      return null;
+    }
     boolean toInstrument = !shouldExclude(cname);
 
     if (toInstrument) {


### PR DESCRIPTION
The className supplied to ClassFileTransformer.transform can be null when the JVM is loading a VM-anonymous class created during the linkage of the invokedynamic call site (part of the evaluation of lambda expressions and method references). When passed a null className, SnoopInstructionTransformer.transform implicitly throws a NullPointerException. It is preferable to avoid the unnecessary overhead of generating the exception and instead return null to indicate that no transformation was performed.