### PR TITLE
Instrument: Optimize thread-local usage of tracers

### DIFF
--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/MultiThreadedTest.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/MultiThreadedTest.java
@@ -1,0 +1,40 @@
+package edu.berkeley.cs.jqf.examples;
+
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class MultiThreadedTest {
+
+    private volatile int counter = 0;
+
+    @Fuzz
+    public void testMultiThreaded(int x) {
+        Thread t1 = new Thread(() -> {
+            if (x > 10) {
+                if (x < 20) {
+                    counter += x;
+                }
+            }
+        });
+        Thread t2 = new Thread(() -> {
+            if (x < 25) {
+                if (x > 15) {
+                    counter += x;
+                }
+            }
+        });
+        t1.start();
+        t2.start();
+        try {
+            t1.join();
+            t2.join();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+
+}

--- a/instrument/src/main/java/edu/berkeley/cs/jqf/instrument/tracing/TraceLogger.java
+++ b/instrument/src/main/java/edu/berkeley/cs/jqf/instrument/tracing/TraceLogger.java
@@ -46,11 +46,35 @@ public class TraceLogger extends AbstractLogger {
 
     private static final TraceLogger singleton = new TraceLogger();
 
-    private final ThreadLocal<ThreadTracer> tracer
+    // Each thread (except the first; see below) has a thread-local tracer object
+    private final ThreadLocal<ThreadTracer> threadLocalTracer
             = ThreadLocal.withInitial(() -> ThreadTracer.spawn(Thread.currentThread()));
+
+    // The first thread is often the main program or test thread
+    private Thread firstThread = null;
+
+    // For performance reasons (e.g. to optimize single-threaded fuzzing), we remember the tracer for this thread
+    private ThreadTracer firstTracer;
 
     private TraceLogger() {
         // Singleton: Prevent outside construction
+    }
+
+    private ThreadTracer getTracer() {
+        // The vast majority of fuzzing sessions are single-threaded; so, return the tracer quickly instead of
+        // looking up the thread-local map. This provides about a 10-20% speedup.
+        if (Thread.currentThread() == firstThread) {
+            return firstTracer;
+        } else if (firstThread == null) {
+            // The first time this method is called, remember the "first" thread and its associated treacer
+            assert firstTracer == null;
+            firstThread = Thread.currentThread();
+            firstTracer = ThreadTracer.spawn(firstThread);
+            return firstTracer;
+        } else {
+            // In multi-threaded fuzzing mode, we have to use thread-local variables
+            return threadLocalTracer.get();
+        }
     }
 
     /**
@@ -65,7 +89,7 @@ public class TraceLogger extends AbstractLogger {
     /** Logs an instrumented byteode instruction for the current thread. */
     @Override
     protected void log(Instruction instruction) {
-        tracer.get().consume(instruction);
+        getTracer().consume(instruction);
     }
 
     /**
@@ -74,14 +98,20 @@ public class TraceLogger extends AbstractLogger {
      * @param event the event to be emitted
      */
     public void emit(TraceEvent event) {
-        tracer.get().emit(event);
+        getTracer().emit(event);
     }
 
     /**
      * Removes the trace logger for the current thread
      */
     public void remove() {
-        tracer.remove();
+        // Make sure to remove the right tracer depending on whether its in the thread-local map or in the field
+        if (Thread.currentThread() == firstThread) {
+            firstTracer = null;
+            firstThread = null;
+        } else {
+            threadLocalTracer.remove();
+        }
     }
 
 }


### PR DESCRIPTION
The change basically gets rid of the use of thread-local tracer objects when fuzzing single-threaded programs, while supporting thread-locals for multi-threaded targets. Since most fuzzing targets are single threaded, this gives a modest performance benefit on most programs.