### PR TITLE
Fix crashes in EI if the instrumentation callback is triggered before fuzzing

### DIFF
--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ExecutionIndexingGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ExecutionIndexingGuidance.java
@@ -334,6 +334,9 @@ public class ExecutionIndexingGuidance extends ZestGuidance {
     /** Handles a trace event generated during test execution */
     @Override
     protected void handleEvent(TraceEvent e) {
+        // Ignore events if the execution hasn't started.
+        if (eiState == null) return;
+
         // Set last event to this event
         lastEvent = e;
 


### PR DESCRIPTION
test with following command 
`./bin/jqf-ei -c $(scripts/examples_classpath.sh) edu.berkeley.cs.jqf.examples.ant.ProjectBuilderTest testWithGenerator`
