### PR TITLE
Remove fast cache for instrumentation class

### DIFF
--- a/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
+++ b/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
@@ -110,7 +110,6 @@ public class SnoopInstructionTransformer implements ClassFileTransformer {
             if (Arrays.equals(cbuf, origBytes)) {
               byte[] instBytes = Files.readAllBytes(cachedFile.toPath());
               println(" Found in disk-cache!");
-              instrumentedBytes.put(cname, instBytes);
               return instBytes;
             }
           } catch (IOException e) {
@@ -139,7 +138,6 @@ public class SnoopInstructionTransformer implements ClassFileTransformer {
       }
 
       println("Done!");
-      instrumentedBytes.put(cname, ret);
 
       if (instDir != null) {
         try {

--- a/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
+++ b/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
@@ -20,11 +20,11 @@ import org.objectweb.asm.ClassWriter;
 public class SnoopInstructionTransformer implements ClassFileTransformer {
   private static final String instDir = Config.instance.instrumentationCacheDir;
   private static final boolean verbose = Config.instance.verbose;
-  
+
   private static String[] banned = {"[", "java/lang", "janala", "org/objectweb/asm", "sun", "jdk", "java/util/function"};
   private static String[] excludes = Config.instance.excludeInst;
   private static String[] includes = Config.instance.includeInst;
-  
+
   public static void premain(String agentArgs, Instrumentation inst) throws ClassNotFoundException {
 
     preloadClasses();
@@ -82,8 +82,6 @@ public class SnoopInstructionTransformer implements ClassFileTransformer {
     return false;
   }
 
-  static Map<String, byte[]> instrumentedBytes = new TreeMap<>();
-
   @Override
   synchronized public byte[] transform(ClassLoader loader, String cname, Class<?> classBeingRedefined,
       ProtectionDomain d, byte[] cbuf)
@@ -102,11 +100,6 @@ public class SnoopInstructionTransformer implements ClassFileTransformer {
       }
       print("Instrumenting: " + cname + "... ");
       GlobalStateForInstrumentation.instance.setCid(cname.hashCode());
-
-      if (instrumentedBytes.containsKey(cname)) {
-        println(" Found in fast-cache!");
-        return instrumentedBytes.get(cname);
-      }
 
       if (instDir != null) {
         File cachedFile = new File(instDir + "/" + cname + ".instrumented.class");

--- a/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
+++ b/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
@@ -20,11 +20,9 @@ import org.objectweb.asm.ClassWriter;
 public class SnoopInstructionTransformer implements ClassFileTransformer {
   private static final String instDir = Config.instance.instrumentationCacheDir;
   private static final boolean verbose = Config.instance.verbose;
-
   private static String[] banned = {"[", "java/lang", "janala", "org/objectweb/asm", "sun", "jdk", "java/util/function"};
   private static String[] excludes = Config.instance.excludeInst;
   private static String[] includes = Config.instance.includeInst;
-
   public static void premain(String agentArgs, Instrumentation inst) throws ClassNotFoundException {
 
     preloadClasses();


### PR DESCRIPTION
This deletes the fast cache in `SnoopInstructionTransformer` since it leads to incorrect behavior when multiple different class loaders for the same class are called. 