### PR TITLE
depIncludes arg for Fuzz and Mutate Goals

### DIFF
--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
@@ -377,9 +377,12 @@ public class FuzzGoal extends AbstractMojo {
                     guidance = new ExecutionIndexingGuidance(targetName, duration, trials, resultsDir, seedsDir, rnd);
                     break;
                 case "mutation":
-                    if (excludes != null || includes == null || depIncludes == null) {
+                    if(depIncludes == null) {
+                        depIncludes = "";
+                    }
+                    if (excludes != null || includes == null) {
                         throw new MojoExecutionException("Mutation-based fuzzing requires " +
-                                "`-Dincludes` and `-DdepIncludes` but not `-Dexcludes");
+                                "`-Dincludes` but not `-Dexcludes");
                     }
                     MutationClassLoaders mcl = new MutationClassLoaders(classPath, includes, depIncludes, ol, baseClassLoader);
                     loader = mcl.getCartographyClassLoader();

--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
@@ -127,6 +127,9 @@ public class FuzzGoal extends AbstractMojo {
     @Parameter(property="includes")
     private String includes;
 
+    @Parameter(property="depIncludes")
+    private String depIncludes;
+
     /**
      * The duration of time for which to run fuzzing.
      *
@@ -374,11 +377,11 @@ public class FuzzGoal extends AbstractMojo {
                     guidance = new ExecutionIndexingGuidance(targetName, duration, trials, resultsDir, seedsDir, rnd);
                     break;
                 case "mutation":
-                    if (excludes != null || includes == null) {
+                    if (excludes != null || includes == null || depIncludes == null) {
                         throw new MojoExecutionException("Mutation-based fuzzing requires " +
-                                "`-Dincludes` but not `-Dexcludes");
+                                "`-Dincludes` and `-DdepIncludes` but not `-Dexcludes");
                     }
-                    MutationClassLoaders mcl = new MutationClassLoaders(classPath, includes, ol, baseClassLoader);
+                    MutationClassLoaders mcl = new MutationClassLoaders(classPath, includes, depIncludes, ol, baseClassLoader);
                     loader = mcl.getCartographyClassLoader();
                     guidance = new MutationGuidance(targetName, mcl, duration, trials, resultsDir, seedsDir, rnd);
                     break;

--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
@@ -127,8 +127,8 @@ public class FuzzGoal extends AbstractMojo {
     @Parameter(property="includes")
     private String includes;
 
-    @Parameter(property="depIncludes")
-    private String depIncludes;
+    @Parameter(property="targetIncludes")
+    private String targetIncludes;
 
     /**
      * The duration of time for which to run fuzzing.
@@ -380,14 +380,14 @@ public class FuzzGoal extends AbstractMojo {
                     guidance = new ExecutionIndexingGuidance(targetName, duration, trials, resultsDir, seedsDir, rnd);
                     break;
                 case "mutation":
-                    if(depIncludes == null) {
-                        depIncludes = "";
+                    if(targetIncludes == null) {
+                        targetIncludes = "";
                     }
                     if (excludes != null || includes == null) {
                         throw new MojoExecutionException("Mutation-based fuzzing requires " +
                                 "`-Dincludes` but not `-Dexcludes");
                     }
-                    MutationClassLoaders mcl = new MutationClassLoaders(classPath, includes, depIncludes, ol, baseClassLoader);
+                    MutationClassLoaders mcl = new MutationClassLoaders(classPath, includes, targetIncludes, ol, baseClassLoader);
                     loader = mcl.getCartographyClassLoader();
                     guidance = new MutationGuidance(targetName, mcl, duration, trials, resultsDir, seedsDir, rnd);
                     break;

--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/MutateGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/MutateGoal.java
@@ -93,6 +93,9 @@ public class MutateGoal extends AbstractMojo {
     @Parameter(property = "includes")
     String includes;
 
+    @Parameter(property="depIncludes")
+    private String depIncludes;
+
     /**
      * classes to be mutated
      */
@@ -122,7 +125,7 @@ public class MutateGoal extends AbstractMojo {
             IOUtils.createDirectory(resultsDir);
 
             // Create mu2 classloaders from the test classpath
-            MutationClassLoaders mcls = new MutationClassLoaders(classPath, includes, ol);
+            MutationClassLoaders mcls = new MutationClassLoaders(classPath, includes, depIncludes, ol);
             CartographyClassLoader ccl = mcls.getCartographyClassLoader();
 
             // Run initial test to compute mutants dynamically

--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/MutateGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/MutateGoal.java
@@ -93,8 +93,8 @@ public class MutateGoal extends AbstractMojo {
     @Parameter(property = "includes")
     String includes;
 
-    @Parameter(property="depIncludes")
-    private String depIncludes;
+    @Parameter(property="targetIncludes")
+    private String targetIncludes;
 
     /**
      * classes to be mutated
@@ -118,8 +118,8 @@ public class MutateGoal extends AbstractMojo {
             throw new MojoExecutionException("Invalid Mutation OptLevel!");
         }
 
-        if(depIncludes == null) {
-            depIncludes = "";
+        if(targetIncludes == null) {
+            targetIncludes = "";
         }
 
         try {
@@ -129,7 +129,7 @@ public class MutateGoal extends AbstractMojo {
             IOUtils.createDirectory(resultsDir);
 
             // Create mu2 classloaders from the test classpath
-            MutationClassLoaders mcls = new MutationClassLoaders(classPath, includes, depIncludes, ol);
+            MutationClassLoaders mcls = new MutationClassLoaders(classPath, includes, targetIncludes, ol);
             CartographyClassLoader ccl = mcls.getCartographyClassLoader();
 
             // Run initial test to compute mutants dynamically

--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/MutateGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/MutateGoal.java
@@ -118,6 +118,10 @@ public class MutateGoal extends AbstractMojo {
             throw new MojoExecutionException("Invalid Mutation OptLevel!");
         }
 
+        if(depIncludes == null) {
+            depIncludes = "";
+        }
+
         try {
             // Get project-specific classpath and output directory
             List<String> classpathElements = project.getTestClasspathElements();


### PR DESCRIPTION
When using mutation guidance, gives user option to enter a comma-separated list of prefixes for all mutable classes and classes that depend on mutable classes for use with Mu2 intermediate classloader.