### PR TITLE
Fix interval computation in FastSourceOfRandomness

### DIFF
--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FastSourceOfRandomness.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FastSourceOfRandomness.java
@@ -110,7 +110,7 @@ public class FastSourceOfRandomness extends SourceOfRandomness {
     }
 
     private int fastChooseIntInRange(int min, int max) {
-        int range = max - min;
+        int range = max - min + 1;
 
         // If range is too wide, overflow will make it negative
         if (range > 0) {


### PR DESCRIPTION
According to
https://github.com/pholser/junit-quickcheck/blob/master/core/src/main/java/com/pholser/junit/quickcheck/random/SourceOfRandomness.java#L257,
`randomInt` should return a value within the range [min, max]. However,
current implementation generates a value within the range [min, max).