### PR TITLE
Increase maximum depth of XML files generated for Maven

### DIFF
--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/maven/ModelReaderTest.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/maven/ModelReaderTest.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import com.pholser.junit.quickcheck.From;
+import com.pholser.junit.quickcheck.generator.Size;
 import edu.berkeley.cs.jqf.examples.xml.XMLDocumentUtils;
 import edu.berkeley.cs.jqf.examples.xml.XmlDocumentGenerator;
 import edu.berkeley.cs.jqf.examples.common.Dictionary;
@@ -63,12 +64,14 @@ public class ModelReaderTest {
 
     @Fuzz
     public void testWithGenerator(@From(XmlDocumentGenerator.class)
+                                      @Size(min = 0, max = 10)
                                       @Dictionary("dictionaries/maven-model.dict") Document dom) {
         testWithInputStream(XMLDocumentUtils.documentToInputStream(dom));
     }
 
     @Fuzz
     public void debugWithGenerator(@From(XmlDocumentGenerator.class)
+                                       @Size(min = 0, max = 10)
                                        @Dictionary("dictionaries/maven-model.dict") Document dom) {
         System.out.println(XMLDocumentUtils.documentToString(dom));
         testWithGenerator(dom);


### PR DESCRIPTION
The default maximum nesting depth for the XML generator is 4. However, the Maven POM specification contains tags that can only be expressed when nested at a greater depth, preventing the generator from covering some code in MavenXpp3Reader that should otherwise be reachable from the driver - for example, `goal` in `<execution>`. This PR increases the maximum depth when generating POM files.
 
```
<project>
  <build>
        <plugins>
            <plugin>
                <artifactId>maven-resources-plugin</artifactId>
                <executions>
                    <execution>
                        <id>copy-seeds</id>
                        <phase>test</phase>
                        <goals>
                            <goal>copy-resources</goal>
                        </goals>
                    </execution>
                </executions>
            </plugin>
      </plugins>
</build>
</project>
```