### PR TITLE
Faster, collision-free coverage instrumentation

### DIFF
--- a/fuzz/pom.xml
+++ b/fuzz/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>picocli</artifactId>
             <version>4.0.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+            <version>10.4.0</version>
+        </dependency>
     </dependencies>
 
 

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/afl/PerfFuzzGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/afl/PerfFuzzGuidance.java
@@ -49,6 +49,7 @@ import edu.berkeley.cs.jqf.instrument.tracing.events.CallEvent;
 import edu.berkeley.cs.jqf.instrument.tracing.events.ReadEvent;
 import edu.berkeley.cs.jqf.instrument.tracing.events.ReturnEvent;
 import edu.berkeley.cs.jqf.instrument.tracing.events.TraceEvent;
+import org.eclipse.collections.api.list.primitive.IntList;
 
 /**
  * A front-end that uses AFL for increasing performance counters
@@ -303,15 +304,13 @@ public class PerfFuzzGuidance extends AFLGuidance {
      *                     one positive integer for each memory access
      * @return     the redundancy score
      */
-    public static double computeRedundancyScore(Collection<Integer> accessCounts) {
+    public static double computeRedundancyScore(IntList accessCounts) {
         double numCounts = accessCounts.size();
         if (numCounts == 0) {
             return 0.0;
         }
         double sumCounts = 0.0;
-        for (int count : accessCounts) {
-            sumCounts += count;
-        }
+        sumCounts = accessCounts.sum();
         double averageCounts = sumCounts / numCounts;
         double score = (averageCounts - 1)*(numCounts - 1)/sumCounts;
 

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ExecutionIndexingGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ExecutionIndexingGuidance.java
@@ -54,6 +54,9 @@ import edu.berkeley.cs.jqf.fuzz.util.ProducerHashMap;
 import edu.berkeley.cs.jqf.instrument.tracing.SingleSnoop;
 import edu.berkeley.cs.jqf.instrument.tracing.events.CallEvent;
 import edu.berkeley.cs.jqf.instrument.tracing.events.TraceEvent;
+import org.eclipse.collections.api.iterator.IntIterator;
+import org.eclipse.collections.api.set.primitive.IntSet;
+import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 
 /**
  * A guidance that represents inputs as maps from
@@ -260,7 +263,9 @@ public class ExecutionIndexingGuidance extends ZestGuidance {
                         savedInputs.set(otherIdx, currentInput);
 
                         // Second, update responsibilities
-                        for (Object b : otherInput.responsibilities) {
+                        IntIterator otherResponsibilitiesIter = otherInput.responsibilities.intIterator();
+                        while(otherResponsibilitiesIter.hasNext()){
+                            int b = otherResponsibilitiesIter.next();
                             // Subsume responsibility
                             // infoLog("-- Stealing responsibility for %s from old input %d", b, otherIdx);
                             // We are now responsible
@@ -272,7 +277,7 @@ public class ExecutionIndexingGuidance extends ZestGuidance {
                         // Third, store basic book-keeping data
                         currentInput.id = otherIdx;
                         currentInput.saveFile = otherInput.saveFile;
-                        currentInput.coverage = new Coverage(runCoverage);
+                        currentInput.coverage = runCoverage.copy();
                         currentInput.nonZeroCoverage = runCoverage.getNonZeroCount();
                         currentInput.offspring = 0;
                         savedInputs.get(currentParentInputIdx).offspring += 1;
@@ -296,7 +301,7 @@ public class ExecutionIndexingGuidance extends ZestGuidance {
 
     /** Saves an interesting input to the queue. */
     @Override
-    protected void saveCurrentInput(Set<Object> responsibilities, String why) throws IOException {
+    protected void saveCurrentInput(IntHashSet responsibilities, String why) throws IOException {
         // First, do same as Zest
         super.saveCurrentInput(responsibilities, why);
 

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
@@ -44,7 +44,6 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
@@ -62,8 +61,15 @@ import edu.berkeley.cs.jqf.fuzz.guidance.GuidanceException;
 import edu.berkeley.cs.jqf.fuzz.guidance.Result;
 import edu.berkeley.cs.jqf.fuzz.guidance.TimeoutException;
 import edu.berkeley.cs.jqf.fuzz.util.Coverage;
+import edu.berkeley.cs.jqf.fuzz.util.CoverageFactory;
+import edu.berkeley.cs.jqf.fuzz.util.ICoverage;
 import edu.berkeley.cs.jqf.fuzz.util.IOUtils;
+import edu.berkeley.cs.jqf.instrument.tracing.FastCoverageSnoop;
 import edu.berkeley.cs.jqf.instrument.tracing.events.TraceEvent;
+import janala.instrument.FastCoverageListener;
+import org.eclipse.collections.api.iterator.IntIterator;
+import org.eclipse.collections.api.list.primitive.IntList;
+import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 
 import static java.lang.Math.ceil;
 import static java.lang.Math.log;
@@ -143,13 +149,13 @@ public class ZestGuidance implements Guidance {
     protected int numSavedInputs = 0;
 
     /** Coverage statistics for a single run. */
-    protected Coverage runCoverage = new Coverage();
+    protected ICoverage runCoverage = CoverageFactory.newInstance();
 
     /** Cumulative coverage statistics. */
-    protected Coverage totalCoverage = new Coverage();
+    protected ICoverage totalCoverage = CoverageFactory.newInstance();
 
     /** Cumulative coverage for valid inputs. */
-    protected Coverage validCoverage = new Coverage();
+    protected ICoverage validCoverage = CoverageFactory.newInstance();
 
     /** The maximum number of keys covered by any single input found so far. */
     protected int maxCoverage = 0;
@@ -277,6 +283,10 @@ public class ZestGuidance implements Guidance {
         this.blind = Boolean.getBoolean("jqf.ei.TOTALLY_RANDOM");
         this.validityFuzzing = !Boolean.getBoolean("jqf.ei.DISABLE_VALIDITY_FUZZING");
         prepareOutputDirectory();
+
+        if(this.runCoverage instanceof FastCoverageListener){
+            FastCoverageSnoop.setFastCoverageListener((FastCoverageListener) this.runCoverage);
+        }
 
         // Try to parse the single-run timeout
         String timeout = System.getProperty("jqf.ei.TIMEOUT");
@@ -729,7 +739,7 @@ public class ZestGuidance implements Guidance {
                 // Newly covered branches are always included.
                 // Existing branches *may* be included, depending on the heuristics used.
                 // A valid input will steal responsibility from invalid inputs
-                Set<Object> responsibilities = computeResponsibilities(valid);
+                IntHashSet responsibilities = computeResponsibilities(valid);
 
                 // Determine if this input should be saved
                 List<String> savingCriteriaSatisfied = checkSavingCriteriaSatisfied(result);
@@ -862,18 +872,18 @@ public class ZestGuidance implements Guidance {
 
 
     // Compute a set of branches for which the current input may assume responsibility
-    protected Set<Object> computeResponsibilities(boolean valid) {
-        Set<Object> result = new HashSet<>();
+    protected IntHashSet computeResponsibilities(boolean valid) {
+        IntHashSet result = new IntHashSet();
 
         // This input is responsible for all new coverage
-        Collection<?> newCoverage = runCoverage.computeNewCoverage(totalCoverage);
+        IntList newCoverage = runCoverage.computeNewCoverage(totalCoverage);
         if (newCoverage.size() > 0) {
             result.addAll(newCoverage);
         }
 
         // If valid, this input is responsible for all new valid coverage
         if (valid) {
-            Collection<?> newValidCoverage = runCoverage.computeNewCoverage(validCoverage);
+            IntList newValidCoverage = runCoverage.computeNewCoverage(validCoverage);
             if (newValidCoverage.size() > 0) {
                 result.addAll(newValidCoverage);
             }
@@ -883,12 +893,13 @@ public class ZestGuidance implements Guidance {
         if (STEAL_RESPONSIBILITY) {
             int currentNonZeroCoverage = runCoverage.getNonZeroCount();
             int currentInputSize = currentInput.size();
-            Set<?> covered = new HashSet<>(runCoverage.getCovered());
+            IntHashSet covered = new IntHashSet();
+            covered.addAll(runCoverage.getCovered());
 
             // Search for a candidate to steal responsibility from
             candidate_search:
             for (Input candidate : savedInputs) {
-                Set<?> responsibilities = candidate.responsibilities;
+                IntHashSet responsibilities = candidate.responsibilities;
 
                 // Candidates with no responsibility are not interesting
                 if (responsibilities.isEmpty()) {
@@ -903,7 +914,9 @@ public class ZestGuidance implements Guidance {
                                 currentInputSize < candidate.size())) {
 
                     // Check if we can steal all responsibilities from candidate
-                    for (Object b : responsibilities) {
+                    IntIterator iter = responsibilities.intIterator();
+                    while(iter.hasNext()){
+                        int b = iter.next();
                         if (covered.contains(b) == false) {
                             // Cannot steal if this input does not cover something
                             // that the candidate is responsible for
@@ -932,7 +945,7 @@ public class ZestGuidance implements Guidance {
     }
 
     /* Saves an interesting input to the queue. */
-    protected void saveCurrentInput(Set<Object> responsibilities, String why) throws IOException {
+    protected void saveCurrentInput(IntHashSet responsibilities, String why) throws IOException {
 
         // First, save to disk (note: we issue IDs to everyone, but only write to disk  if valid)
         int newInputIdx = numSavedInputs++;
@@ -953,14 +966,16 @@ public class ZestGuidance implements Guidance {
         // Third, store basic book-keeping data
         currentInput.id = newInputIdx;
         currentInput.saveFile = saveFile;
-        currentInput.coverage = new Coverage(runCoverage);
+        currentInput.coverage = runCoverage.copy();
         currentInput.nonZeroCoverage = runCoverage.getNonZeroCount();
         currentInput.offspring = 0;
         savedInputs.get(currentParentInputIdx).offspring += 1;
 
         // Fourth, assume responsibility for branches
         currentInput.responsibilities = responsibilities;
-        for (Object b : responsibilities) {
+        IntIterator iter = responsibilities.intIterator();
+        while(iter.hasNext()){
+            int b = iter.next();
             // If there is an old input that is responsible,
             // subsume it
             Input oldResponsible = responsibleInputs.get(b);
@@ -989,12 +1004,15 @@ public class ZestGuidance implements Guidance {
     /**
      * Handles a trace event generated during test execution.
      *
+     * Not used by FastNonCollidingCoverage, which does not allocate an
+     * instance of TraceEvent at each branch probe execution.
+     *
      * @param e the trace event to be handled
      */
     protected void handleEvent(TraceEvent e) {
         conditionallySynchronize(multiThreaded, () -> {
             // Collect totalCoverage
-            runCoverage.handleEvent(e);
+            ((Coverage) runCoverage).handleEvent(e);
             // Check for possible timeouts every so often
             if (this.singleRunTimeoutMillis > 0 &&
                     this.runStart != null && (++this.branchCount) % 10_000 == 0) {
@@ -1010,7 +1028,7 @@ public class ZestGuidance implements Guidance {
      * Returns a reference to the coverage statistics.
      * @return a reference to the coverage statistics
      */
-    public Coverage getTotalCoverage() {
+    public ICoverage getTotalCoverage() {
         return totalCoverage;
     }
 
@@ -1061,7 +1079,7 @@ public class ZestGuidance implements Guidance {
          *
          * <p>This field is null for inputs that are not saved.</p>
          */
-        Coverage coverage = null;
+        ICoverage coverage = null;
 
         /**
          * The number of non-zero elements in `coverage`.
@@ -1093,7 +1111,7 @@ public class ZestGuidance implements Guidance {
          * in at least some responsibility set. Hence, this list
          * needs to be kept in-sync with {@link #responsibleInputs}.</p>
          */
-        Set<Object> responsibilities = null;
+        IntHashSet responsibilities = null;
 
         /**
          * Create an empty input.

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/repro/ReproServerGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/repro/ReproServerGuidance.java
@@ -105,7 +105,7 @@ public class ReproServerGuidance implements Guidance {
 
         // Print coverage
         try (PrintWriter out = new PrintWriter(coverageFile)) {
-            coverage.getCovered().stream().sorted().forEach((i) ->
+            coverage.getCovered().toSortedList().forEach((i) ->
                 out.println(String.format("%05d", i))
             );
             out.println(result.toString()); // EOF marker for tools to realize that repro is done

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/Counter.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/Counter.java
@@ -28,6 +28,9 @@
  */
 package edu.berkeley.cs.jqf.fuzz.util;
 
+import org.eclipse.collections.api.list.primitive.IntList;
+import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -183,8 +186,8 @@ public class Counter {
      *
      * @return a set of indices at which the count is non-zero
      */
-    public Collection<Integer> getNonZeroIndices() {
-        List<Integer> indices = new ArrayList<>(size /2);
+    public IntList getNonZeroIndices() {
+        IntArrayList indices = new IntArrayList(size /2);
         for (int i = 0; i < counts.length; i++) {
             int count = counts[i];
             if (count != 0) {
@@ -199,8 +202,8 @@ public class Counter {
      *
      * @return a set of non-zero count values in this counter.
      */
-    public Collection<Integer> getNonZeroValues() {
-        List<Integer> values = new ArrayList<>(size /2);
+    public IntList getNonZeroValues() {
+        IntArrayList values = new IntArrayList(size /2);
         for (int i = 0; i < counts.length; i++) {
             int count = counts[i];
             if (count != 0) {

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/CoverageFactory.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/CoverageFactory.java
@@ -1,0 +1,33 @@
+package edu.berkeley.cs.jqf.fuzz.util;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class CoverageFactory {
+
+    public static final String propFile = System.getProperty("janala.conf", "janala.conf");
+
+    private static boolean FAST_NON_COLLIDING_COVERAGE_ENABLED;
+    static
+    {
+        Properties properties = new Properties();
+        try (InputStream propStream = new FileInputStream(propFile)) {
+            properties.load(propStream);
+        } catch (IOException e) {
+            // Swallow exception and continue with defaults
+            // System.err.println("Warning: No janala.conf file found");
+        }
+        properties.putAll(System.getProperties());
+        FAST_NON_COLLIDING_COVERAGE_ENABLED = Boolean.parseBoolean(properties.getProperty("useFastNonCollidingCoverageInstrumentation", "false"));
+    }
+
+    public static ICoverage newInstance() {
+        if (FAST_NON_COLLIDING_COVERAGE_ENABLED) {
+            return new FastNonCollidingCoverage();
+        } else {
+            return new Coverage();
+        }
+    }
+}

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/FastNonCollidingCounter.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/FastNonCollidingCounter.java
@@ -1,0 +1,164 @@
+package edu.berkeley.cs.jqf.fuzz.util;
+
+import org.eclipse.collections.api.iterator.IntIterator;
+import org.eclipse.collections.api.list.primitive.IntList;
+import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
+import org.eclipse.collections.impl.map.mutable.primitive.IntIntHashMap;
+
+/**
+ * An implementation of  {@link Counter} that uses an IntIntHashMap to store values
+ *
+ * "Fast" in that it is faster than using something that involves other HashMaps,
+ * and boxing to-and-from primitive values. There is surely a way to make it *faster*
+ * than this too, without avoiding the collisions, but given the performance improvement
+ * compared to the original (and collision-prone) coverage, I made the opinionated decision
+ * to implement it this way to avoid other concerns from high collisions rates on some particular
+ * target applications. Further experimentation with fast (non-colliding) coverage implementations
+ * might help to determine which approach is preferable.
+ *
+ * @author Jonathan Bell
+ */
+public class FastNonCollidingCounter extends Counter {
+    /** The counter map as a map of integers. */
+    IntIntHashMap counts;
+
+    /* List of indices in the map that are non-zero */
+    protected IntArrayList nonZeroKeys;
+
+    /**
+     * Creates a new counter
+     */
+    public FastNonCollidingCounter(int size) {
+        super(1);
+        this.counts = new IntIntHashMap(size);
+        this.nonZeroKeys = new IntArrayList(size / 2);
+    }
+
+
+    /**
+     * Returns the size of this counter.
+     *
+     * @return the size of this counter
+     */
+    public synchronized int size() {
+        return this.counts.size();
+    }
+
+    /**
+     * Clears the counter by setting all values to zero.
+     */
+    public synchronized void clear() {
+        this.counts.clear();
+        this.nonZeroKeys.clear();
+    }
+
+    /**
+     * Increments the count at the given key.
+     *
+     *
+     * @param key the key whose count to increment
+     * @return the new value after incrementing the count
+     */
+    public synchronized int increment(int key) {
+        int newVal = this.counts.addToValue(key, 1);
+        if (newVal == 1) {
+            this.nonZeroKeys.add(key);
+        }
+        return newVal;
+    }
+
+    /**
+     *
+     * Increments the count at the given key by a given delta.
+     *
+     * @param key the key whose count to increment
+     * @param delta the amount to increment by
+     * @return the new value after incrementing the count
+     */
+    public synchronized int increment(int key, int delta) {
+        int newVal = this.counts.addToValue(key, delta);
+        if (newVal == delta) {
+            nonZeroKeys.add(key);
+        }
+        return newVal;
+    }
+
+    @Override
+    protected int incrementAtIndex(int index, int delta) {
+        throw new UnsupportedOperationException("This coverage is already non-colliding, please just use get");
+    }
+
+    @Override
+    public void setAtIndex(int idx, int value) {
+        throw new UnsupportedOperationException("This coverage is already non-colliding, please just use setAtIndex");
+    }
+
+    @Override
+    public int getAtIndex(int idx) {
+        throw new UnsupportedOperationException("This coverage is already non-colliding, please just use set");
+    }
+
+    /**
+     * Returns the number of indices with non-zero counts.
+     *
+     * @return the number of indices with non-zero counts
+     */
+    public synchronized int getNonZeroSize() {
+        return nonZeroKeys.size();
+    }
+
+
+    /**
+     * Returns a set of keys at which the count is non-zero.
+     *
+     * @return a set of keys at which the count is non-zero
+     */
+    public synchronized IntList getNonZeroKeys() {
+        return this.nonZeroKeys;
+    }
+
+    public IntList getNonZeroIndices(){
+        return this.getNonZeroKeys();
+    }
+
+    /**
+     * Returns a set of non-zero count values in this counter.
+     *
+     * @return a set of non-zero count values in this counter.
+     */
+    public synchronized IntList getNonZeroValues() {
+        IntArrayList values = new IntArrayList(this.counts.size() / 2);
+        IntIterator iter = this.counts.values().intIterator();
+        while (iter.hasNext()) {
+            int val = iter.next();
+            if (val != 0) {
+                values.add(val);
+            }
+        }
+        return values;
+    }
+
+    /**
+     * Retreives a value for a given key.
+     *
+     * <p>The key is first hashed to retreive a value from
+     * the counter, and hence the result is modulo collisions.</p>
+     *
+     * @param key the key to query
+     * @return the count for the index corresponding to this key
+     */
+    public synchronized  int get(int key) {
+        return this.counts.get(key);
+    }
+
+    public synchronized void copyFrom(FastNonCollidingCounter counter) {
+        this.counts = new IntIntHashMap(counter.counts);
+        this.nonZeroKeys = new IntArrayList(counter.nonZeroKeys.size());
+        this.nonZeroKeys.addAll(counter.nonZeroKeys);
+    }
+
+    @Override
+    public boolean hasNonZeros() {
+        return !this.nonZeroKeys.isEmpty();
+    }
+}

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/ICoverage.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/ICoverage.java
@@ -1,0 +1,60 @@
+package edu.berkeley.cs.jqf.fuzz.util;
+
+import org.eclipse.collections.api.list.primitive.IntList;
+
+public interface ICoverage<T extends Counter> {
+    /**
+     * Returns the size of the coverage map.
+     *
+     * @return the size of the coverage map
+     */
+    int size();
+
+    /**
+     * Returns the number of edges covered.
+     *
+     * @return the number of edges with non-zero counts
+     */
+    int getNonZeroCount();
+
+    /**
+     * Returns a collection of branches that are covered.
+     *
+     * @return a collection of keys that are covered
+     */
+    IntList getCovered();
+
+    /**
+     * Returns a set of edges in this coverage that don't exist in baseline
+     *
+     * @param baseline the baseline coverage
+     * @return the set of edges that do not exist in {@code baseline}
+     */
+    IntList computeNewCoverage(ICoverage baseline);
+
+    /**
+     * Clears the coverage map.
+     */
+    void clear();
+
+    /**
+     * Updates this coverage with bits from the parameter.
+     *
+     * @param that the run coverage whose bits to OR
+     *
+     * @return <code>true</code> iff <code>that</code> is not a subset
+     *         of <code>this</code>, causing <code>this</code> to change.
+     */
+    boolean updateBits(ICoverage that);
+
+    /**
+     * Returns a hash code of the list of edges that have been covered at least once.
+     *
+     * @return a hash of non-zero entries
+     */
+    int nonZeroHashCode();
+
+    Counter getCounter();
+
+    ICoverage<T> copy();
+}

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/MapOfCounters.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/MapOfCounters.java
@@ -28,6 +28,9 @@
  */
 package edu.berkeley.cs.jqf.fuzz.util;
 
+import org.eclipse.collections.api.list.primitive.IntList;
+import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -76,11 +79,11 @@ public class MapOfCounters {
         counters[idx].increment(k2);
     }
 
-    public Collection<Integer> nonZeroCountsAtIndex(int idx) {
+    public IntList nonZeroCountsAtIndex(int idx) {
         if (counters[idx] != null) {
             return counters[idx].getNonZeroValues();
         } else {
-            return Collections.emptyList();
+            return new IntArrayList(0);
         }
 
     }

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/NonZeroCachingCounter.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/NonZeroCachingCounter.java
@@ -28,6 +28,10 @@
  */
 package edu.berkeley.cs.jqf.fuzz.util;
 
+import org.eclipse.collections.api.iterator.IntIterator;
+import org.eclipse.collections.api.list.primitive.IntList;
+import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -44,21 +48,23 @@ public class NonZeroCachingCounter extends Counter {
 
     private int nonZeroCount;
 
-    private Collection<Integer> nonZeroIndices;
+    private IntArrayList nonZeroIndices;
 
     public NonZeroCachingCounter(int size) {
         super(size);
         this.nonZeroCount = 0;
-        this.nonZeroIndices = new ArrayList<>();
+        this.nonZeroIndices = new IntArrayList();
     }
 
     @Override
     public void clear() {
-        for (int idx : nonZeroIndices) {
+        IntIterator iter = nonZeroIndices.intIterator();
+        while(iter.hasNext()){
+            int idx = iter.next();
             counts[idx] = 0;
         }
         this.nonZeroCount = 0;
-        this.nonZeroIndices.clear();
+        this.nonZeroIndices = new IntArrayList();
     }
 
 
@@ -84,14 +90,16 @@ public class NonZeroCachingCounter extends Counter {
     }
 
     @Override
-    public Collection<Integer> getNonZeroIndices() {
+    public IntList getNonZeroIndices() {
         return nonZeroIndices;
     }
 
     @Override
-    public Collection<Integer> getNonZeroValues() {
-        List<Integer> values = new ArrayList<>(size /2);
-        for (int idx : nonZeroIndices) {
+    public IntList getNonZeroValues() {
+        IntArrayList values = new IntArrayList(this.size / 2);
+        IntIterator iter = nonZeroIndices.intIterator();
+        while(iter.hasNext()){
+            int idx = iter.next();
             int count = counts[idx];
             assert (count != 0);
             values.add(count);

--- a/fuzz/src/test/java/edu/berkeley/cs/jqf/fuzz/afl/RedundancyTest.java
+++ b/fuzz/src/test/java/edu/berkeley/cs/jqf/fuzz/afl/RedundancyTest.java
@@ -37,6 +37,7 @@ import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.generator.InRange;
 import com.pholser.junit.quickcheck.generator.Size;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
 import org.junit.Assert;
 import org.junit.runner.RunWith;
 
@@ -68,14 +69,18 @@ public class RedundancyTest {
         Assert.assertTrue(root*root == squareSum);
 
 
-        List<Integer> redundantCounts = new ArrayList<>(root);
+        IntArrayList redundantCounts = new IntArrayList(root);
         for (int i = 0; i < root; i++) {
             redundantCounts.add(root);
         }
-        Assert.assertTrue(sum(redundantCounts) == squareSum);
+        Assert.assertTrue(redundantCounts.sum() == squareSum);
 
+        IntArrayList countsIntArrayList = new IntArrayList(counts.size());
+        for(int i : counts){
+            countsIntArrayList.add(i);
+        }
         // Compute redundancy score for some memory accesses
-        double score = PerfFuzzGuidance.computeRedundancyScore(counts);
+        double score = PerfFuzzGuidance.computeRedundancyScore(countsIntArrayList);
 
         // Ensure that scores are in [0, 1)
         Assert.assertTrue(score >= 0 && score < 1);

--- a/fuzz/src/test/java/edu/berkeley/cs/jqf/fuzz/util/CountersTest.java
+++ b/fuzz/src/test/java/edu/berkeley/cs/jqf/fuzz/util/CountersTest.java
@@ -28,11 +28,14 @@
  */
 package edu.berkeley.cs.jqf.fuzz.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.generator.InRange;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.eclipse.collections.api.iterator.IntIterator;
+import org.eclipse.collections.api.list.primitive.IntList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -103,14 +106,11 @@ public class CountersTest {
             counter.increment(key, delta);
         }
 
-        Collection<Integer> nonZeroValues = counter.getNonZeroValues();
+        IntList nonZeroValues = counter.getNonZeroValues();
         assertThat(nonZeroValues.size(), lessThanOrEqualTo(keys.length));
 
 
-        int sum = 0;
-        for (int v : nonZeroValues) {
-            sum += v;
-        }
+        int sum = (int) nonZeroValues.sum();
 
         assertEquals(keys.length * delta, sum);
 
@@ -123,8 +123,8 @@ public class CountersTest {
             counter.increment(key, delta);
         }
 
-        Collection<Integer> nonZeroIndices = counter.getNonZeroIndices();
-        Collection<Integer> nonZeroValues = counter.getNonZeroValues();
+        IntList nonZeroIndices = counter.getNonZeroIndices();
+        IntList nonZeroValues = counter.getNonZeroValues();
         assertEquals(nonZeroValues.size(), nonZeroIndices.size());
 
     }
@@ -138,9 +138,18 @@ public class CountersTest {
         }
 
         int nonZeroSize = counter.getNonZeroSize();
-        Collection<Integer> nonZeroValues = counter.getNonZeroValues();
+        IntList nonZeroValues = counter.getNonZeroValues();
         assertEquals(nonZeroValues.size(), nonZeroSize);
 
+    }
+
+    static ArrayList<Integer> toCollection(IntList primIntList){
+        ArrayList<Integer> ret = new ArrayList<>(primIntList.size());
+        IntIterator iter = primIntList.intIterator();
+        while(iter.hasNext()){
+            ret.add(iter.next());
+        }
+        return ret;
     }
 
     @Property
@@ -151,8 +160,8 @@ public class CountersTest {
 
 
         int nonZeroSize = counter.getNonZeroSize();
-        Collection<Integer> nonZeroIndices = counter.getNonZeroIndices();
-        Collection<Integer> nonZeroValues = counter.getNonZeroValues();
+        ArrayList<Integer> nonZeroIndices = toCollection(counter.getNonZeroIndices());
+        ArrayList<Integer> nonZeroValues = toCollection(counter.getNonZeroValues());
         if (value == 0) {
             assertThat(nonZeroSize, is(0));
             assertThat(nonZeroIndices, iterableWithSize(0));
@@ -188,8 +197,8 @@ public class CountersTest {
         }
 
         assertThat(counter.getNonZeroSize(), is(0));
-        assertThat(counter.getNonZeroIndices(), iterableWithSize(0));
-        assertThat(counter.getNonZeroValues(), iterableWithSize(0));
+        assertThat(toCollection(counter.getNonZeroIndices()), iterableWithSize(0));
+        assertThat(toCollection(counter.getNonZeroValues()), iterableWithSize(0));
     }
 
     @Test

--- a/fuzz/src/test/java/edu/berkeley/cs/jqf/fuzz/util/NonZeroCachingCountersTest.java
+++ b/fuzz/src/test/java/edu/berkeley/cs/jqf/fuzz/util/NonZeroCachingCountersTest.java
@@ -28,12 +28,17 @@
  */
 package edu.berkeley.cs.jqf.fuzz.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.generator.InRange;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.eclipse.collections.api.iterator.IntIterator;
+import org.eclipse.collections.api.list.primitive.IntList;
+import org.eclipse.collections.impl.list.mutable.primitive.IntArrayList;
+import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import org.junit.runner.RunWith;
 
 import static org.hamcrest.Matchers.*;
@@ -104,9 +109,9 @@ public class NonZeroCachingCountersTest {
             counter2.increment(key, delta);
         }
 
-        Collection<Integer> nonZeroValues1 = counter1.getNonZeroValues();
-        Collection<Integer> nonZeroValues2 = counter2.getNonZeroValues();
-        assertEquals(new HashSet<>(nonZeroValues1), new HashSet<>(nonZeroValues2));
+        IntList nonZeroValues1 = counter1.getNonZeroValues();
+        IntList nonZeroValues2 = counter2.getNonZeroValues();
+        assertEquals(IntHashSet.newSet(nonZeroValues1), IntHashSet.newSet(nonZeroValues2));
 
     }
 
@@ -119,9 +124,9 @@ public class NonZeroCachingCountersTest {
             counter2.increment(key, delta);
         }
 
-        Collection<Integer> nonZeroIndices1 = counter1.getNonZeroIndices();
-        Collection<Integer> nonZeroIndices2 = counter2.getNonZeroIndices();
-        assertEquals(new HashSet<>(nonZeroIndices1), new HashSet<>(nonZeroIndices2));
+        IntList nonZeroIndices1 = counter1.getNonZeroIndices();
+        IntList nonZeroIndices2 = counter2.getNonZeroIndices();
+        assertEquals(IntHashSet.newSet(nonZeroIndices1), IntHashSet.newSet(nonZeroIndices2));
 
     }
 
@@ -141,6 +146,14 @@ public class NonZeroCachingCountersTest {
 
     }
 
+    static ArrayList<Integer> toJavaArrayList(IntList primitiveList){
+        ArrayList<Integer> ret = new ArrayList<>(primitiveList.size());
+        IntIterator iter = primitiveList.intIterator();
+        while(iter.hasNext()){
+            ret.add(iter.next());
+        }
+        return ret;
+    }
     @Property
     public void setAtIndexWorks(@InRange(minInt=0, maxInt=COUNTER_SIZE-1) int index, int value) {
         Counter counter = new NonZeroCachingCounter(COUNTER_SIZE);
@@ -149,8 +162,8 @@ public class NonZeroCachingCountersTest {
 
 
         int nonZeroSize = counter.getNonZeroSize();
-        Collection<Integer> nonZeroIndices = counter.getNonZeroIndices();
-        Collection<Integer> nonZeroValues = counter.getNonZeroValues();
+        Collection<Integer> nonZeroIndices = toJavaArrayList(counter.getNonZeroIndices());
+        Collection<Integer> nonZeroValues = toJavaArrayList(counter.getNonZeroValues());
         if (value == 0) {
             assertThat(nonZeroSize, is(0));
             assertThat(nonZeroIndices, iterableWithSize(0));
@@ -186,7 +199,7 @@ public class NonZeroCachingCountersTest {
         }
 
         assertThat(counter.getNonZeroSize(), is(0));
-        assertThat(counter.getNonZeroIndices(), iterableWithSize(0));
-        assertThat(counter.getNonZeroValues(), iterableWithSize(0));
+        assertThat(toJavaArrayList(counter.getNonZeroIndices()), iterableWithSize(0));
+        assertThat(toJavaArrayList(counter.getNonZeroValues()), iterableWithSize(0));
     }
 }

--- a/instrument/src/main/java/edu/berkeley/cs/jqf/instrument/tracing/FastCoverageSnoop.java
+++ b/instrument/src/main/java/edu/berkeley/cs/jqf/instrument/tracing/FastCoverageSnoop.java
@@ -1,0 +1,45 @@
+package edu.berkeley.cs.jqf.instrument.tracing;
+
+import janala.instrument.FastCoverageListener;
+
+public class FastCoverageSnoop {
+    static FastCoverageListener coverageListener = new FastCoverageListener() {
+        @Override
+        public void logCoverage(int iid, int arm) {
+
+        }
+    };
+
+    @SuppressWarnings("unused") //Invoked by instrumentation
+    public static void LOGJUMP(int iid, int branch) {
+        coverageListener.logCoverage(iid, branch);
+    }
+
+    @SuppressWarnings("unused") //Invoked by instrumentation
+    public static void LOGLOOKUPSWITCH(int value, int iid, int dflt, int[] cases) {
+        // Compute arm index or else default
+        int arm = cases.length;
+        for (int i = 0; i < cases.length; i++) {
+            if (value == cases[i]) {
+                arm = i;
+                break;
+            }
+        }
+        arm++;
+        coverageListener.logCoverage(iid, arm);
+    }
+
+    @SuppressWarnings("unused") //Invoked by instrumentation
+    public static void LOGTABLESWITCH(int value, int iid, int min, int max, int dflt) {
+        int arm = 1 + max - min;
+        if (value >= min && value <= max) {
+            arm = value - min;
+        }
+        arm++;
+        coverageListener.logCoverage(iid, arm);
+    }
+
+    public static void setFastCoverageListener(FastCoverageListener runCoverage) {
+        coverageListener = runCoverage;
+    }
+}

--- a/instrument/src/main/java/janala/instrument/Config.java
+++ b/instrument/src/main/java/janala/instrument/Config.java
@@ -18,6 +18,7 @@ class Config {
   public final boolean instrumentHeapLoad;
   public final boolean instrumentAlloc;
   public final String instrumentationCacheDir;
+  public final boolean useFastCoverageInstrumentation;
 
   private Config() {
       // Read properties from the conf file
@@ -34,13 +35,23 @@ class Config {
 
       verbose = Boolean.parseBoolean(properties.getProperty("janala.verbose", "false"));
 
-      analysisClass =
-              properties.getProperty("janala.snoopClass", "edu.berkeley.cs.jqf.instrument.tracing.SingleSnoop")
-                      .replace('.', '/');
+      useFastCoverageInstrumentation = Boolean.parseBoolean(properties.getProperty("useFastNonCollidingCoverageInstrumentation", "false"));
+      if(useFastCoverageInstrumentation){
+          analysisClass = "edu/berkeley/cs/jqf/instrument/tracing/FastCoverageSnoop";
+      } else {
+          analysisClass =
+                  properties.getProperty("janala.snoopClass", "edu.berkeley.cs.jqf.instrument.tracing.SingleSnoop")
+                          .replace('.', '/');
+      }
 
 
       instrumentHeapLoad = Boolean.parseBoolean(properties.getProperty("janala.instrumentHeapLoad", "false"));
       instrumentAlloc = Boolean.parseBoolean(properties.getProperty("janala.instrumentAlloc", "false"));
+
+      if((instrumentAlloc || instrumentHeapLoad) && useFastCoverageInstrumentation){
+          throw new UnsupportedOperationException("It is currently not possible to use allocation or heap load tracking in conjunction with fast coverage");
+      }
+
 
       String excludeInstStr = properties.getProperty("janala.excludes", null);
       if (excludeInstStr != null) {

--- a/instrument/src/main/java/janala/instrument/FastCoverageListener.java
+++ b/instrument/src/main/java/janala/instrument/FastCoverageListener.java
@@ -1,0 +1,5 @@
+package janala.instrument;
+
+public interface FastCoverageListener {
+    public void logCoverage(int iid, int arm);
+}

--- a/instrument/src/main/java/janala/instrument/FastCoverageMethodAdapter.java
+++ b/instrument/src/main/java/janala/instrument/FastCoverageMethodAdapter.java
@@ -78,7 +78,7 @@ public class FastCoverageMethodAdapter extends MethodVisitor implements Opcodes 
   private void addConditionalJumpInstrumentation(int opcode, Label finalBranchTarget,
                                                  String instMethodName, String instMethodDesc) {
     int iid = instrumentationState.incAndGetFastCoverageId();
-    instrumentationState.incAndGetId(); //reserve another counter for the other side of this branch
+    instrumentationState.incAndGetFastCoverageId(); //reserve another counter for the other side of this branch
 
     Label intermediateBranchTarget = new Label();
     Label fallthrough = new Label();

--- a/instrument/src/main/java/janala/instrument/FastCoverageMethodAdapter.java
+++ b/instrument/src/main/java/janala/instrument/FastCoverageMethodAdapter.java
@@ -1,0 +1,215 @@
+package janala.instrument;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class FastCoverageMethodAdapter extends MethodVisitor implements Opcodes {
+  boolean isInit;
+  boolean isSuperInitCalled; // Used to keep track of calls to super()/this() in <init>()
+  int newStack = 0; // Used to keep-track of NEW instructions in <init>()
+
+  private final String className;
+  private final String superName;
+
+  private final GlobalStateForInstrumentation instrumentationState;
+
+  public FastCoverageMethodAdapter(MethodVisitor mv, String className,
+                                   String methodName, String descriptor, String superName,
+                                   GlobalStateForInstrumentation instrumentationState) {
+    super(ASM8, mv);
+    this.isInit = methodName.equals("<init>");
+    this.isSuperInitCalled = false;
+    this.className = className;
+    this.superName = superName;
+
+    this.instrumentationState = instrumentationState;
+  }
+
+  /** Push a value onto the stack. */
+  private static void addBipushInsn(MethodVisitor mv, int val) {
+    Utils.addBipushInsn(mv, val);
+  }
+
+  @Override
+  public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+    if (opcode == INVOKESPECIAL && name.equals("<init>")) {
+
+
+      // The first call to <init> within a constructor (`isInit`) on the same or super class,
+      // which is not associated with a NEW instruction (`newStack` == 0),
+      // will be considered as an invocation of super()/this().
+
+      if (isInit && isSuperInitCalled == false && newStack == 0 &&
+              (owner.equals(className) || owner.equals(superName))) {
+        // Constructor calls to <init> method of the same or super class.
+        //
+        // XXX: This is a hack. We assume that if we see an <init> to same or
+        // super class, then it must be a super() or this() call. However,
+        // there are counter-examples such as `public Foo() { super(new Foo()); }`,
+        // which will cause broken class files. This comment is here as a forewarning
+        // for when this situation is eventually encountered due to a bytecode
+        // verification error due to stack-map frames not matching up.
+        //
+        // In this case, we do not wrap the method call in try catch block as
+        // it uses uninitialized this object.
+        isSuperInitCalled = true;
+      } else {
+        // Call to <init> but not a super() or this(). Must have occurred after a NEW.
+        // This is an outer constructor call, so reduce the NEW stack
+        if (isInit) {
+          newStack--;
+          assert newStack >= 0;
+        }
+      }
+    }
+    mv.visitMethodInsn(opcode, owner, name, desc, itf);
+  }
+
+  @Override
+  public void visitCode() {
+    super.visitCode();
+    int iid = instrumentationState.incAndGetFastCoverageId();
+    addBipushInsn(mv, iid);
+    mv.visitInsn(ICONST_0);
+    mv.visitMethodInsn(INVOKESTATIC, Config.instance.analysisClass, "LOGJUMP", "(II)V", false);
+  }
+
+  private void addConditionalJumpInstrumentation(int opcode, Label finalBranchTarget,
+                                                 String instMethodName, String instMethodDesc) {
+    int iid = instrumentationState.incAndGetFastCoverageId();
+    instrumentationState.incAndGetId(); //reserve another counter for the other side of this branch
+
+    Label intermediateBranchTarget = new Label();
+    Label fallthrough = new Label();
+
+    // Perform the original jump, but branch to intermediate label
+    mv.visitJumpInsn(opcode, intermediateBranchTarget);
+    // If we did not jump, skip to the fallthrough
+    mv.visitJumpInsn(GOTO, fallthrough);
+
+    // Now instrument the branch target
+    mv.visitLabel(intermediateBranchTarget);
+    addBipushInsn(mv, iid);
+    addBipushInsn(mv, 1); // Mark branch as taken
+    mv.visitMethodInsn(INVOKESTATIC, Config.instance.analysisClass, instMethodName, instMethodDesc, false);
+    mv.visitJumpInsn(GOTO, finalBranchTarget); // Go to actual branch target
+
+    // Now instrument the fall through
+    mv.visitLabel(fallthrough);
+    addBipushInsn(mv, iid);
+    addBipushInsn(mv, 0); // Mark branch as not taken
+    mv.visitMethodInsn(INVOKESTATIC, Config.instance.analysisClass, instMethodName, instMethodDesc, false);
+
+    // continue with fall-through code visiting
+  }
+
+  @Override
+  public void visitJumpInsn(int opcode, Label label) {
+    if (isInit && !isSuperInitCalled) {
+      // Jumps in a constructor before super() or this() mess up the analysis
+      throw new RuntimeException("Cannot handle jumps before super/this");
+    }
+
+    switch (opcode) {
+      case IFEQ:
+      case IFNE:
+      case IFLT:
+      case IFGE:
+      case IFGT:
+      case IFLE:
+      case IF_ICMPEQ:
+      case IF_ICMPNE:
+      case IF_ICMPLT:
+      case IF_ICMPGE:
+      case IF_ICMPGT:
+      case IF_ICMPLE:
+      case IF_ACMPEQ:
+      case IF_ACMPNE:
+      case IFNULL:
+      case IFNONNULL:
+        addConditionalJumpInstrumentation(opcode, label,  "LOGJUMP", "(II)V");
+        break;
+      case GOTO:
+      case JSR:
+        mv.visitJumpInsn(opcode, label);
+        break;
+      default:
+        throw new RuntimeException("Unknown jump opcode " + opcode);
+    }
+  }
+
+  private Integer lastLineNumber = 0;
+
+  @Override
+  public void visitLineNumber(int lineNumber, Label label) {
+    lastLineNumber = lineNumber;
+    mv.visitLineNumber(lineNumber, label);
+  }
+
+
+  private int getLabelNum(Label label) {
+    return System.identityHashCode(label);
+  }
+
+
+
+
+
+  @Override
+  public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
+    // Save operand value
+    //addValueReadInsn(mv, "I", "GETVALUE_");
+    mv.visitInsn(Opcodes.DUP);
+    // Log switch instruction
+    addBipushInsn(mv, instrumentationState.incAndGetFastCoverageId());
+    addBipushInsn(mv, min);
+    addBipushInsn(mv, max);
+    addBipushInsn(mv, getLabelNum(dflt));
+
+    for (int i = 0; i < labels.length; i++) {
+      //create a coverage probe for each of the arms, we'll refer to it by offset
+      instrumentationState.incAndGetFastCoverageId();
+    }
+
+
+    //create a coverage probe for the default case
+    instrumentationState.incAndGetFastCoverageId();
+    mv.visitMethodInsn(INVOKESTATIC, Config.instance.analysisClass, "LOGTABLESWITCH", "(IIIII)V", false);
+    mv.visitTableSwitchInsn(min, max, dflt, labels);
+  }
+
+
+  @Override
+  public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
+    // Save operand value
+    mv.visitInsn(Opcodes.DUP);
+
+    // Log switch instruction
+    addBipushInsn(mv, instrumentationState.incAndGetFastCoverageId());
+    addBipushInsn(mv, getLabelNum(dflt));
+
+    addBipushInsn(mv, keys.length);
+    mv.visitIntInsn(NEWARRAY, T_INT);
+    for (int i = 0; i < keys.length; i++) {
+      mv.visitInsn(DUP);
+      addBipushInsn(mv, i);
+      addBipushInsn(mv, keys[i]);
+      mv.visitInsn(IASTORE);
+      //create a coverage probe for each of the arms, we'll refer to it by offset
+      instrumentationState.incAndGetFastCoverageId();
+    }
+
+
+    //create a coverage probe for the default case
+    instrumentationState.incAndGetFastCoverageId();
+    mv.visitMethodInsn(INVOKESTATIC, Config.instance.analysisClass, "LOGLOOKUPSWITCH", "(III[I)V", false);
+    mv.visitLookupSwitchInsn(dflt, keys, labels);
+  }
+
+  @Override
+  public void visitMaxs(int maxStack, int maxLocals) {
+    //Allow ASM to calculate the correct maxStack by passing '0' as the maximum stack value.
+    mv.visitMaxs(0, maxLocals);
+  }
+}

--- a/instrument/src/main/java/janala/instrument/FastCoverageMethodAdapter.java
+++ b/instrument/src/main/java/janala/instrument/FastCoverageMethodAdapter.java
@@ -33,6 +33,11 @@ public class FastCoverageMethodAdapter extends MethodVisitor implements Opcodes 
 
   @Override
   public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
+    int iid = instrumentationState.incAndGetFastCoverageId();
+    addBipushInsn(mv, iid);
+    mv.visitInsn(ICONST_0);
+    mv.visitMethodInsn(INVOKESTATIC, Config.instance.analysisClass, "LOGJUMP", "(II)V", false);
+
     if (opcode == INVOKESPECIAL && name.equals("<init>")) {
 
 
@@ -69,10 +74,6 @@ public class FastCoverageMethodAdapter extends MethodVisitor implements Opcodes 
   @Override
   public void visitCode() {
     super.visitCode();
-    int iid = instrumentationState.incAndGetFastCoverageId();
-    addBipushInsn(mv, iid);
-    mv.visitInsn(ICONST_0);
-    mv.visitMethodInsn(INVOKESTATIC, Config.instance.analysisClass, "LOGJUMP", "(II)V", false);
   }
 
   private void addConditionalJumpInstrumentation(int opcode, Label finalBranchTarget,

--- a/instrument/src/main/java/janala/instrument/GlobalStateForInstrumentation.java
+++ b/instrument/src/main/java/janala/instrument/GlobalStateForInstrumentation.java
@@ -8,6 +8,14 @@ public class GlobalStateForInstrumentation {
   private int mid = 0;
   private int cid = 0;
 
+  // JQF's Fast Coverage implementation uses a plain int, no bit packing, no truncation errors
+  private int fastCoverageIID = 0;
+  public int incAndGetFastCoverageId(){
+    fastCoverageIID++;
+    return fastCoverageIID;
+  }
+
+
   // When one gets the id, she gets the result of merging all three ids.
   // NOTE: Beaware of truncation errors.
   private final static int CBITS = 10;  // CID occupies the upper 10 bits

--- a/instrument/src/main/java/janala/instrument/SnoopInstructionClassAdapter.java
+++ b/instrument/src/main/java/janala/instrument/SnoopInstructionClassAdapter.java
@@ -28,12 +28,16 @@ public class SnoopInstructionClassAdapter extends ClassVisitor {
   }
 
   @Override
-  public MethodVisitor visitMethod(int access, String name, String desc, 
+  public MethodVisitor visitMethod(int access, String name, String desc,
       String signature, String[] exceptions) {
     MethodVisitor mv = cv.visitMethod(access, name, desc, signature, exceptions);
     if (mv != null) {
-      return new SnoopInstructionMethodAdapter(mv, className, name, desc, superName,
-          GlobalStateForInstrumentation.instance);
+      if(Config.instance.useFastCoverageInstrumentation){
+        return new FastCoverageMethodAdapter(mv, className, name, desc, superName, GlobalStateForInstrumentation.instance);
+      }else {
+        return new SnoopInstructionMethodAdapter(mv, className, name, desc, superName,
+                GlobalStateForInstrumentation.instance);
+      }
     }
     return null;
   }

--- a/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
+++ b/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
@@ -20,7 +20,7 @@ import org.objectweb.asm.ClassWriter;
 public class SnoopInstructionTransformer implements ClassFileTransformer {
   private static final String instDir = Config.instance.instrumentationCacheDir;
   private static final boolean verbose = Config.instance.verbose;
-  private static String[] banned = {"[", "java/lang", "org/eclipse/collections", "janala", "org/objectweb/asm", "sun", "jdk", "java/util/function"};
+  private static String[] banned = {"[", "java/lang", "org/eclipse/collections", "edu/berkeley/cs/jqf/fuzz/util", "janala", "org/objectweb/asm", "sun", "jdk", "java/util/function"};
   private static String[] excludes = Config.instance.excludeInst;
   private static String[] includes = Config.instance.includeInst;
   public static void premain(String agentArgs, Instrumentation inst) throws ClassNotFoundException {

--- a/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
+++ b/instrument/src/main/java/janala/instrument/SnoopInstructionTransformer.java
@@ -20,7 +20,7 @@ import org.objectweb.asm.ClassWriter;
 public class SnoopInstructionTransformer implements ClassFileTransformer {
   private static final String instDir = Config.instance.instrumentationCacheDir;
   private static final boolean verbose = Config.instance.verbose;
-  private static String[] banned = {"[", "java/lang", "janala", "org/objectweb/asm", "sun", "jdk", "java/util/function"};
+  private static String[] banned = {"[", "java/lang", "org/eclipse/collections", "janala", "org/objectweb/asm", "sun", "jdk", "java/util/function"};
   private static String[] excludes = Config.instance.excludeInst;
   private static String[] includes = Config.instance.includeInst;
   public static void premain(String agentArgs, Instrumentation inst) throws ClassNotFoundException {


### PR DESCRIPTION
While implementing novel guidance improvements to JQF + Zest (to be described in our soon-to-be-published CONFETTI paper at ICSE), we found that the default coverage implementation that JQF was unusually slow. From profiling, we found that the current coverage implementation that JQF provides uses the Janala instrumentation framework, which provides a generic framework for recording and inspecting various program events, and for this flexibility, imposes a significant performance burden. We also noted issues where our more targeted guidance would fail to make progress on particular branches because the newly covered branches weren't detected as covered, since their probes collided with other branches.

This PR includes a complete coverage implementation that is both faster than the current implementation provided by JQF, and is also collision-free. It is enabled by setting the flag `-DuseFastNonCollidingCoverageInstrumentation=true`. There were several changes that I had to make to existing code to enable this extensibility - most notably introducing the ICoverage interface, and refactoring uses of Java collections with boxed primitives (slow to box and unbox for every branch execution) to instead use Eclipse primitive collections.

I conducted a [24 hour x 20 trial evaluation](https://ci.in.ripley.cloud/logs/public/jon-bell/fuzzing-build-site-action/22f896cb235349b924d86d2db2311ddc439fe1ea/Compare%20Fuzzing%20Branches/1631812756/1/site/) comparing the performance of this coverage implementation to the JQF implementation. In terms of execution speed, the difference is quite dramatic, with the fast-collision-free-coverage implementation executing roughly 7-10x as many inputs in the same 24 hour period.

Note that because there are no collisions on probes, the branch probes vs time graph provides a built-in advantage to fast-collision-free-coverage (there are more probes that can be covered), but I have also included JaCoCo coverage results after reproducing the entire saved corpus of each fuzzing run. JaCoCo branch coverage was same-or-better in all cases for fast-collision-free-coverage.

Note that on Maven, the revision of fast-collision-free-coverage that I executed did *not* include the recent patch to increase the generator coverage - it underperforms the normal coverage implementation only for that reason.

I do not have an automated pipeline to deduplicate the failures and determine the intersection and unique crashes found in each campaign, but the failures are all linked from the report.

I am not sure what the downside, if any, is to making this the default coverage implementation - I suspect that some changes may be needed to other `Guidance` implementations to be sure that they work correctly still beyond running the test suite. However, I think having the option to use this instrumentation might be a big win for future development that adds more nuanced guidance.

If you have any suggestions, I would be happy to incorporate them and regenerate the evaluation. Thank you for building and maintaining this valuable infrastructure!