### PR TITLE
Add a new example to test branch coverage.

### DIFF
--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/simple/SimpleClass.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/simple/SimpleClass.java
@@ -1,0 +1,18 @@
+package edu.berkeley.cs.jqf.examples.simple;
+
+public class SimpleClass {
+    public static int test(int a) {
+        int b = 0;
+        if (a > 0) {
+            b += 1;
+        } else {
+            b -= 1;
+        }
+        if (a % 2 == 0) {
+            b += 1;
+        } else {
+            b -= 1;
+        }
+        return b;
+    }
+}

--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/simple/SimpleClassTest.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/simple/SimpleClassTest.java
@@ -1,0 +1,29 @@
+package edu.berkeley.cs.jqf.examples.simple;
+
+import com.pholser.junit.quickcheck.From;
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+import edu.berkeley.cs.jqf.fuzz.Fuzz;
+import edu.berkeley.cs.jqf.fuzz.JQF;
+import org.junit.runner.RunWith;
+
+@RunWith(JQF.class)
+public class SimpleClassTest {
+
+    public static class SimpleGenerator extends Generator<Integer> {
+        public SimpleGenerator() {
+            super(Integer.class);
+        }
+
+        @Override
+        public Integer generate(SourceOfRandomness sourceOfRandomness, GenerationStatus generationStatus) {
+            return sourceOfRandomness.nextInt();
+        }
+    }
+
+    @Fuzz
+    public void testWithGenerator(@From(SimpleGenerator.class) Integer a) {
+        SimpleClass.test(a);
+    }
+}

--- a/integration-tests/src/test/java/edu/berkeley/cs/jqf/fuzz/guidance/ZestGuidanceIT.java
+++ b/integration-tests/src/test/java/edu/berkeley/cs/jqf/fuzz/guidance/ZestGuidanceIT.java
@@ -67,4 +67,23 @@ public class ZestGuidanceIT extends AbstractGuidanceIT {
         Assert.assertEquals(-684278400, zest.hashTotalCoverage());
         Assert.assertEquals(-1096184368, zest.hashValidCoverage());
     }
+
+
+    // This function tests if the instrumentation framework of Zest handles
+    // branch instructions in the target program properly.
+    @Test
+    public void testSimpleTestCoverage() throws Exception {
+        String clazz = "edu.berkeley.cs.jqf.examples.simple.SimpleClassTest";
+        String method = "testWithGenerator";
+
+        long trials = 5000;
+        Random rnd = new Random(42);
+
+        ProbedZestGuidance zest = new ProbedZestGuidance("SimpleClassTest", trials, rnd);
+        GuidedFuzzing.run(clazz, method, classLoader, zest, null);
+
+        // Validate result
+        Assert.assertEquals(7, zest.getTotalCoverage().getNonZeroCount());
+
+    }
 }


### PR DESCRIPTION
You may use the command `mvn jqf:fuzz -Dengine=zest
-Dclass=edu.berkeley.cs.jqf.examples.simple.SimpleClassTest
-Dmethod=testWithGenerator` to run the new test.

If the instrumentation framework is implemented correctly, the coverage should be higher than or equal to 6.