### PR TITLE
feat: adding a system property to enable/disable exception swallow

### DIFF
--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
@@ -73,6 +73,7 @@ public class FuzzStatement extends Statement {
     private final List<Class<?>> expectedExceptions;
     private final List<Throwable> failures = new ArrayList<>();
     private final Guidance guidance;
+    private boolean skipExceptionSwallow;
 
     public FuzzStatement(FrameworkMethod method, TestClass testClass,
                          GeneratorRepository generatorRepository, Guidance fuzzGuidance) {
@@ -83,6 +84,7 @@ public class FuzzStatement extends Statement {
         this.generatorRepository = generatorRepository;
         this.expectedExceptions = Arrays.asList(method.getMethod().getExceptionTypes());
         this.guidance = fuzzGuidance;
+        this.skipExceptionSwallow = Boolean.getBoolean("skipExceptionSwallow");
     }
 
     /**
@@ -206,6 +208,9 @@ public class FuzzStatement extends Statement {
      * in the <code>throws</code> clause of the trial method.
      */
     private boolean isExceptionExpected(Class<? extends Throwable> e) {
+        if (skipExceptionSwallow) {
+            return false;
+        }
         for (Class<?> expectedException : expectedExceptions) {
             if (expectedException.isAssignableFrom(e)) {
                 return true;

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
@@ -84,7 +84,7 @@ public class FuzzStatement extends Statement {
         this.generatorRepository = generatorRepository;
         this.expectedExceptions = Arrays.asList(method.getMethod().getExceptionTypes());
         this.guidance = fuzzGuidance;
-        this.skipExceptionSwallow = Boolean.getBoolean("skipExceptionSwallow");
+        this.skipExceptionSwallow = Boolean.getBoolean("jqf.failOnDeclaredExceptions");
     }
 
     /**


### PR DESCRIPTION
This PR adds a system property called `skipExceptionSwallow` to disable exception swallow.

This is useful when the `throws` clause is used in the method signature but users still want to indicate failure for expected exceptions.

With this PR, one can disable exception swallow by adding the `-DskipExceptionSwallow` argument through the command line.