### PR TITLE
Update JavaScriptCodeGenerator.java

### DIFF
--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/js/JavaScriptCodeGenerator.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/js/JavaScriptCodeGenerator.java
@@ -259,7 +259,7 @@ public class JavaScriptCodeGenerator extends Generator<String> {
         return "if (" +
                 generateExpression(random) + ") " +
                 generateBlock(random) +
-                (random.nextBoolean() ? generateBlock(random) : "");
+                (random.nextBoolean() ? " else " + generateBlock(random) : "");
     }
 
     private String generateIndexNode(SourceOfRandomness random) {


### PR DESCRIPTION
The `generateIfNode` method forgets to add else keyword.