### PR TITLE
JavaClassGenerator Improvements

### DIFF
--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/FieldGenerator.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/FieldGenerator.java
@@ -1,0 +1,119 @@
+package edu.berkeley.cs.jqf.examples.bcel;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.java.lang.StringGenerator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.AccessFlags;
+import org.apache.bcel.classfile.Field;
+import org.apache.bcel.generic.BasicType;
+import org.apache.bcel.generic.ClassGen;
+import org.apache.bcel.generic.FieldGen;
+import org.apache.bcel.generic.Type;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Based on:
+ * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html">
+ * Java Virtual Machine Specification 4
+ * </a>
+ */
+public final class FieldGenerator {
+    private static final List<Consumer<? super AccessFlags>> VISIBILITY_SETTERS =
+            Arrays.asList((f) -> f.isPrivate(true), (f) -> f.isPublic(true), (f) -> f.isProtected(true), (f) -> {
+            });
+    private final Generator<String> identifierGenerator = new JavaIdentifierGenerator();
+    private final Generator<String> stringConstantGenerator = new StringGenerator();
+    private final TypeGenerator typeGenerator;
+    private final SourceOfRandomness random;
+    private final GenerationStatus status;
+    private final ClassGen clazz;
+
+    public FieldGenerator(SourceOfRandomness random, GenerationStatus status, ClassGen clazz) {
+        this.random = random;
+        this.status = status;
+        this.clazz = clazz;
+        this.typeGenerator = new TypeGenerator(random, status);
+    }
+
+    public Field generate() {
+        Type type = typeGenerator.generate();
+        String name = identifierGenerator.generate(random, status);
+        FieldGen field = new FieldGen(0, type, name, clazz.getConstantPool());
+        setAccessFlags(field);
+        if (field.isFinal()) {
+            setInitValue(type, field);
+        }
+        return field.getField();
+    }
+
+    private void setInitValue(Type type, FieldGen field) {
+        if (type instanceof BasicType) {
+            if (random.nextBoolean()) {
+                switch (type.getType()) {
+                    case Const.T_BOOLEAN:
+                        field.setInitValue(random.nextBoolean());
+                        break;
+                    case Const.T_BYTE:
+                        field.setInitValue(random.nextByte(Byte.MIN_VALUE, Byte.MAX_VALUE));
+                        break;
+                    case Const.T_SHORT:
+                        field.setInitValue(random.nextShort(Short.MIN_VALUE, Short.MAX_VALUE));
+                        break;
+                    case Const.T_CHAR:
+                        field.setInitValue(random.nextChar(Character.MIN_VALUE, Character.MAX_VALUE));
+                        break;
+                    case Const.T_INT:
+                        field.setInitValue(random.nextInt());
+                        break;
+                    case Const.T_LONG:
+                        field.setInitValue(random.nextLong());
+                        break;
+                    case Const.T_DOUBLE:
+                        field.setInitValue(random.nextDouble());
+                        break;
+                    case Const.T_FLOAT:
+                        field.setInitValue(random.nextFloat());
+                        break;
+                }
+            }
+        } else if (type.equals(Type.STRING)) {
+            if (random.nextBoolean()) {
+                field.setInitValue(stringConstantGenerator.generate(random, status));
+            }
+        }
+    }
+
+    void setAccessFlags(FieldGen field) {
+        if (random.nextBoolean()) {
+            field.isSynthetic(true);
+        }
+        if (clazz.isInterface()) {
+            field.isPublic(true);
+            field.isStatic(true);
+            field.isFinal(true);
+        } else {
+            random.choose(VISIBILITY_SETTERS).accept(field);
+            if (random.nextBoolean()) {
+                field.isStatic(true);
+            }
+            if (random.nextBoolean()) {
+                field.isTransient(true);
+            }
+            if (random.nextBoolean()) {
+                field.isEnum(true);
+            }
+            switch (random.nextInt(3)) {
+                case 0:
+                    field.isFinal(true);
+                    break;
+                case 1:
+                    field.isVolatile(true);
+            }
+        }
+    }
+}

--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/JavaClassGenerator.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/JavaClassGenerator.java
@@ -28,503 +28,108 @@
  */
 package edu.berkeley.cs.jqf.examples.bcel;
 
-
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
 import com.pholser.junit.quickcheck.generator.Generator;
-import com.pholser.junit.quickcheck.internal.GeometricDistribution;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 import org.apache.bcel.Const;
-import org.apache.bcel.classfile.Field;
 import org.apache.bcel.classfile.JavaClass;
-import org.apache.bcel.classfile.Method;
-import org.apache.bcel.generic.*;
-import org.junit.Assume;
-import org.junit.AssumptionViolatedException;
+import org.apache.bcel.generic.ClassGen;
+import org.apache.bcel.generic.ConstantPoolGen;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 /**
- * @author Rohan Padhye
+ * Based on:
+ * <a href="https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html">
+ * Java Virtual Machine Specification 4
+ * </a>
  */
 public class JavaClassGenerator extends Generator<JavaClass> {
-
-    private ConstantPoolGen constants;
-
-    private String[] primitiveTypes = {
-            "Z", "B", "C", "S", "I", "J", "F", "D"
-    };
-
-    private String[] interestingClasses = {
-            "java/lang/Object",
-            "java/lang/Integer",
-            "java/util/List",
-            "java/util/Map",
-            "example/A",
-            "example/B"
-    };
-
-
-    private String[] memberDictionary = {
-            "foo",
-            "bar",
-            "baz",
-            "example",
-            "A",
-            "B",
-            "C",
-            "D"
-    };
-
-    private static GeometricDistribution geom = new GeometricDistribution();
-
-
-    // Constants
-    private static double MEAN_INTERFACE_COUNT = 1.2;
-    private static double MEAN_FIELDS_COUNT = 2;
-    private static double MEAN_METHODS_COUNT = 1.5;
-    private static double MEAN_ARRAY_DEPTH = 1.2;
+    private static final int MIN_FIELDS = 0;
+    private static final int MAX_FIELDS = 10;
+    private static final int MIN_INTERFACES = 0;
+    private static final int MAX_INTERFACES = 5;
+    private static final int MIN_METHODS = 0;
+    private static final int MAX_METHODS = 10;
+    private static final List<Consumer<ClassGen>> versionList =
+            Collections.unmodifiableList(Arrays.asList((clazz) -> setVersion(clazz, Const.MAJOR_1_1, Const.MINOR_1_1),
+                    (clazz) -> setVersion(clazz, Const.MAJOR_1_2, Const.MINOR_1_2),
+                    (clazz) -> setVersion(clazz, Const.MAJOR_1_3, Const.MINOR_1_3),
+                    (clazz) -> setVersion(clazz, Const.MAJOR_1_4, Const.MINOR_1_4),
+                    (clazz) -> setVersion(clazz, Const.MAJOR_1_5, Const.MINOR_1_5),
+                    (clazz) -> setVersion(clazz, Const.MAJOR_1_6, Const.MINOR_1_6),
+                    (clazz) -> setVersion(clazz, Const.MAJOR_1_7, Const.MINOR_1_7),
+                    (clazz) -> setVersion(clazz, Const.MAJOR_1_8, Const.MINOR_1_8),
+                    (clazz) -> setVersion(clazz, Const.MAJOR_1_9, Const.MINOR_1_9)));
+    private final Generator<String> classNameGenerator = new JavaClassNameGenerator(".");
 
     public JavaClassGenerator() {
         super(JavaClass.class);
     }
 
-    public JavaClass generate(SourceOfRandomness r, GenerationStatus s) {
-        constants = new ConstantPoolGen();
-
-        // Generate a class with its meta-data
-        String className = "example.A";
-        String superName = r.nextBoolean() ? "example.B" : "java.lang.Object";
-        String fileName = "A.class";
-        int flags = r.nextInt(0, Short.MAX_VALUE);
-        int numInterfaces = r.nextBoolean() ? 0 : geom.sampleWithMean(MEAN_INTERFACE_COUNT, r);
-        String[] interfaces = new String[numInterfaces];
-        for (int i = 0; i < numInterfaces; i++) {
-            interfaces[i] = "example.I"+i;
-        }
-        ClassGen classGen = new ClassGen(className, superName, fileName, flags, interfaces, constants);
-
-        // Validate flags
-        Assume.assumeFalse(classGen.isFinal() && (classGen.isAbstract() | classGen.isInterface()));
-
-        int numFields = geom.sampleWithMean(MEAN_FIELDS_COUNT, r);
-        for (int i = 0; i < numFields; i++) {
-            classGen.addField(generateField(r));
-        }
-
-        int numMethods = geom.sampleWithMean(MEAN_METHODS_COUNT, r);
-        for (int i = 0; i < numMethods; i++) {
-            classGen.addMethod(generateMethod(className, r));
-        }
-
-        return classGen.getJavaClass();
-
+    public JavaClass generate(SourceOfRandomness random, GenerationStatus status) {
+        ConstantPoolGen pool = new ConstantPoolGen();
+        String className = classNameGenerator.generate(random, status);
+        String superClassName = classNameGenerator.generate(random, status);
+        String fileName = className.replace('.', '/') + ".class";
+        ClassGen clazz = new ClassGen(className, superClassName, fileName, 0, new String[0], pool);
+        setVersion(random, clazz);
+        setAccessFlags(random, clazz);
+        Stream.generate(() -> classNameGenerator.generate(random, status))
+                .limit(random.nextInt(MIN_INTERFACES, MAX_INTERFACES))
+                .forEach(clazz::addInterface);
+        Stream.generate(new FieldGenerator(random, status, clazz)::generate)
+                .limit(random.nextInt(MIN_FIELDS, MAX_FIELDS))
+                .forEach(clazz::addField);
+        Stream.generate(new MethodGenerator(random, status, clazz)::generate)
+                .limit(random.nextInt(MIN_METHODS, MAX_METHODS))
+                .forEach(clazz::addMethod);
+        return clazz.getJavaClass();
     }
 
-    private Field generateField(SourceOfRandomness r) {
-        int flags = r.nextInt(0, Short.MAX_VALUE);
-        Type type = generateType(r, true);
-        String name = generateMemberName(r);
-        FieldGen fieldGen = new FieldGen(flags, type, name, constants);
-        return fieldGen.getField();
-    }
-
-    private Method generateMethod(String className, SourceOfRandomness r) {
-        int flags = r.nextInt(0, Short.MAX_VALUE);
-        Type returnType = r.nextBoolean() ? Type.VOID : generateType(r, true);
-        String methodName = generateMemberName(r);
-        int numArgs = r.nextInt(4);
-        Type[] argTypes = new Type[numArgs];
-        String[] argNames = new String[numArgs];
-        for (int i = 0; i < numArgs; i++) {
-            argTypes[i] = generateType(r, true);
-            argNames[i] = generateMemberName(r);
+    static void setAccessFlags(SourceOfRandomness random, ClassGen clazz) {
+        if (random.nextBoolean()) {
+            clazz.isPublic(true);
         }
-        InstructionList code = generateCode(r, argTypes, returnType);
-        MethodGen methodGen = new MethodGen(flags, returnType, argTypes, argNames, methodName, className, code, constants);
-        // Validate flags
-        Assume.assumeFalse(methodGen.isFinal() && methodGen.isAbstract());
-        return methodGen.getMethod();
-    }
-
-    private String generateMemberName(SourceOfRandomness r) {
-        if (r.nextBoolean()) {
-            return r.choose(memberDictionary);
+        if (random.nextBoolean()) {
+            clazz.isSynthetic(true);
         }
-        return r.nextChar('a', 'z') + "_" + r.nextInt(10);
-    }
-
-    private String generateTypeSignature(SourceOfRandomness r, boolean arraysAllowed) {
-        String typeSig;
-        if (r.nextBoolean()) {
-            // Primitive
-            typeSig = r.choose(primitiveTypes);
-        } else {
-            // Class type
-            typeSig = "L" + generateClassName(r) + ";";
-        }
-        if (arraysAllowed && r.nextBoolean()) {
-            // Generate array depth with geometric distribution
-            int depth = geom.sampleWithMean(MEAN_ARRAY_DEPTH, r);
-            for (int i = 0; i < depth; i++) {
-                typeSig = "[" + typeSig;
-            }
-        }
-        return typeSig;
-    }
-
-    private Type generateType(SourceOfRandomness r, boolean arraysAllowed) {
-        return Type.getType(generateTypeSignature(r, arraysAllowed));
-    }
-
-    private InstructionList generateCode(SourceOfRandomness r, Type[] argTypes, Type returnType) {
-        InstructionList code = new InstructionList();
-
-        while (r.nextBoolean()) {
-            Instruction ins = generateInstruction(r, argTypes.length+1, code); // TODO: Allocate some locals
-            if (ins instanceof BranchInstruction) {
-                // Call the overloaded append()
-                code.append((BranchInstruction) ins);
+        if (random.nextBoolean()) {
+            // Abstract
+            clazz.isAbstract(true);
+            if (random.nextBoolean()) {
+                clazz.isInterface(true);
+                if (random.nextBoolean()) {
+                    clazz.isAnnotation(true);
+                }
             } else {
-                code.append(ins);
+                if (random.nextBoolean()) {
+                    clazz.isEnum(true);
+                }
+            }
+        } else {
+            // Concrete
+            if (random.nextBoolean()) {
+                clazz.isEnum(true);
+            }
+            if (random.nextBoolean()) {
+                clazz.isFinal(true);
             }
         }
-        return code;
     }
 
-    private Instruction generateInstruction(SourceOfRandomness r, int slots, InstructionList code) {
-
-        int opcode = r.nextInt(256);
-        Instruction ins = InstructionConst.getInstruction(opcode);
-        if (ins != null) {
-            return ins; // Used predefined immutable object, if available
-        }
-
-        switch (opcode) {
-            case Const.BIPUSH:
-                ins = new BIPUSH(r.nextByte(Byte.MIN_VALUE, Byte.MAX_VALUE));
-                break;
-            case Const.SIPUSH:
-                ins = new SIPUSH(r.nextShort(Short.MIN_VALUE, Short.MAX_VALUE));
-                break;
-            case Const.LDC:
-                ins = new LDC(constants.addString("?")); // TODO: Generate constants
-                break;
-            case Const.LDC_W:
-                ins = new LDC(constants.addString("?")); // TODO: Generate constants
-                break;
-            case Const.LDC2_W:
-                ins = new LDC2_W(constants.addDouble(Math.PI));
-                break;
-            case Const.ILOAD:
-                ins = new ILOAD(r.nextInt(slots));
-                break;
-            case Const.LLOAD:
-                ins = new LLOAD(r.nextInt(slots));
-                break;
-            case Const.FLOAD:
-                ins = new FLOAD(r.nextInt(slots));
-                break;
-            case Const.DLOAD:
-                ins = new DLOAD(r.nextInt(slots));
-                break;
-            case Const.ALOAD:
-                ins = new ALOAD(r.nextInt(slots));
-                break;
-            case Const.ILOAD_0:
-                ins = new ILOAD(0);
-                break;
-            case Const.ILOAD_1:
-                ins = new ILOAD(1);
-                break;
-            case Const.ILOAD_2:
-                ins = new ILOAD(2);
-                break;
-            case Const.ILOAD_3:
-                ins = new ILOAD(3);
-                break;
-            case Const.LLOAD_0:
-                ins = new LLOAD(0);
-                break;
-            case Const.LLOAD_1:
-                ins = new LLOAD(1);
-                break;
-            case Const.LLOAD_2:
-                ins = new LLOAD(2);
-                break;
-            case Const.LLOAD_3:
-                ins = new LLOAD(3);
-                break;
-            case Const.FLOAD_0:
-                ins = new FLOAD(0);
-                break;
-            case Const.FLOAD_1:
-                ins = new FLOAD(1);
-                break;
-            case Const.FLOAD_2:
-                ins = new FLOAD(2);
-                break;
-            case Const.FLOAD_3:
-                ins = new FLOAD(3);
-                break;
-            case Const.DLOAD_0:
-                ins = new DLOAD(0);
-                break;
-            case Const.DLOAD_1:
-                ins = new DLOAD(1);
-                break;
-            case Const.DLOAD_2:
-                ins = new DLOAD(2);
-                break;
-            case Const.DLOAD_3:
-                ins = new DLOAD(3);
-                break;
-            case Const.ALOAD_0:
-                ins = new ALOAD(0);
-                break;
-            case Const.ALOAD_1:
-                ins = new ALOAD(1);
-                break;
-            case Const.ALOAD_2:
-                ins = new ALOAD(2);
-                break;
-            case Const.ALOAD_3:
-                ins = new ALOAD(3);
-                break;
-            case Const.ISTORE:
-                ins = new ISTORE(r.nextInt(slots));
-                break;
-            case Const.LSTORE:
-                ins = new LSTORE(r.nextInt(slots));
-                break;
-            case Const.FSTORE:
-                ins = new FSTORE(r.nextInt(slots));
-                break;
-            case Const.DSTORE:
-                ins = new DSTORE(r.nextInt(slots));
-                break;
-            case Const.ASTORE:
-                ins = new ASTORE(r.nextInt(slots));
-                break;
-            case Const.ISTORE_0:
-                ins = new ISTORE(0);
-                break;
-            case Const.ISTORE_1:
-                ins = new ISTORE(1);
-                break;
-            case Const.ISTORE_2:
-                ins = new ISTORE(2);
-                break;
-            case Const.ISTORE_3:
-                ins = new ISTORE(3);
-                break;
-            case Const.LSTORE_0:
-                ins = new LSTORE(0);
-                break;
-            case Const.LSTORE_1:
-                ins = new LSTORE(1);
-                break;
-            case Const.LSTORE_2:
-                ins = new LSTORE(2);
-                break;
-            case Const.LSTORE_3:
-                ins = new LSTORE(3);
-                break;
-            case Const.FSTORE_0:
-                ins = new FSTORE(0);
-                break;
-            case Const.FSTORE_1:
-                ins = new FSTORE(1);
-                break;
-            case Const.FSTORE_2:
-                ins = new FSTORE(2);
-                break;
-            case Const.FSTORE_3:
-                ins = new FSTORE(3);
-                break;
-            case Const.DSTORE_0:
-                ins = new DSTORE(0);
-                break;
-            case Const.DSTORE_1:
-                ins = new DSTORE(1);
-                break;
-            case Const.DSTORE_2:
-                ins = new DSTORE(2);
-                break;
-            case Const.DSTORE_3:
-                ins = new DSTORE(3);
-                break;
-            case Const.ASTORE_0:
-                ins = new ASTORE(0);
-                break;
-            case Const.ASTORE_1:
-                ins = new ASTORE(1);
-                break;
-            case Const.ASTORE_2:
-                ins = new ASTORE(2);
-                break;
-            case Const.ASTORE_3:
-                ins = new ASTORE(3);
-                break;
-            case Const.IINC:
-                ins = new IINC(r.nextInt(slots), r.nextInt(-128, 128));
-                break;
-            case Const.IFEQ:
-                ins = new IFEQ(generateLabel(r, code));
-                break;
-            case Const.IFNE:
-                ins = new IFNE(generateLabel(r, code));
-                break;
-            case Const.IFLT:
-                ins = new IFLT(generateLabel(r, code));
-                break;
-            case Const.IFGE:
-                ins = new IFGE(generateLabel(r, code));
-                break;
-            case Const.IFGT:
-                ins = new IFGT(generateLabel(r, code));
-                break;
-            case Const.IFLE:
-                ins = new IFLE(generateLabel(r, code));
-                break;
-            case Const.IF_ICMPEQ:
-                ins = new IF_ICMPEQ(generateLabel(r, code));
-                break;
-            case Const.IF_ICMPNE:
-                ins = new IF_ICMPNE(generateLabel(r, code));
-                break;
-            case Const.IF_ICMPLT:
-                ins = new IF_ICMPLT(generateLabel(r, code));
-                break;
-            case Const.IF_ICMPGE:
-                ins = new IF_ICMPGE(generateLabel(r, code));
-                break;
-            case Const.IF_ICMPGT:
-                ins = new IF_ICMPGT(generateLabel(r, code));
-                break;
-            case Const.IF_ICMPLE:
-                ins = new IF_ICMPLE(generateLabel(r, code));
-                break;
-            case Const.IF_ACMPEQ:
-                ins = new IF_ACMPEQ(generateLabel(r, code));
-                break;
-            case Const.IF_ACMPNE:
-                ins = new IF_ACMPNE(generateLabel(r, code));
-                break;
-            case Const.GOTO:
-                ins = new GOTO(generateLabel(r, code));
-                break;
-                /*
-            case Const.JSR:
-                ins = new JSR(generateLabel(r));
-                break;
-            case Const.RET:
-                ins = new RET(r.nextInt(slots));
-                break;
-            case Const.TABLESWITCH:
-                ins = new TABLESWITCH();
-                break;
-            case Const.LOOKUPSWITCH:
-                ins = new LOOKUPSWITCH();
-                break;
-               */
-            case Const.GETSTATIC:
-                ins = new GETSTATIC(generateFieldRef(r));
-                break;
-            case Const.PUTSTATIC:
-                ins = new PUTSTATIC(generateFieldRef(r));
-                break;
-            case Const.GETFIELD:
-                ins = new GETFIELD(generateFieldRef(r));
-                break;
-            case Const.PUTFIELD:
-                ins = new PUTFIELD(generateFieldRef(r));
-                break;
-            case Const.INVOKEVIRTUAL:
-                ins = new INVOKEVIRTUAL(generateMethodRef(r));
-                break;
-            case Const.INVOKESPECIAL:
-                ins = new INVOKESPECIAL(generateMethodRef(r));
-                break;
-            case Const.INVOKESTATIC:
-                ins = new INVOKESTATIC(generateMethodRef(r));
-                break;
-            case Const.INVOKEINTERFACE:
-                ins = new INVOKEINTERFACE(generateMethodRef(r), r.nextInt(1, 4));
-                break;
-            case Const.INVOKEDYNAMIC:
-                ins = new INVOKEDYNAMIC(generateMethodRef(r));
-                break;
-            case Const.NEW:
-                ins = new NEW(generateClassRef(r));
-                break;
-            case Const.NEWARRAY:
-                ins = new NEWARRAY(r.nextByte((byte) 4, (byte) 12)); // TODO: Document basic type codes
-                break;
-            case Const.ANEWARRAY:
-                ins = new ANEWARRAY(generateClassRef(r));
-                break;
-            case Const.CHECKCAST:
-                ins = new CHECKCAST(generateClassRef(r));
-                break;
-            case Const.INSTANCEOF:
-                ins = new INSTANCEOF(generateClassRef(r));
-                break;
-            case Const.MULTIANEWARRAY:
-                ins = new MULTIANEWARRAY(generateClassRef(r), r.nextShort((short) 1 , Short.MAX_VALUE));
-                break;
-            case Const.IFNULL:
-                ins = new IFNULL(generateLabel(r, code));
-                break;
-            case Const.IFNONNULL:
-                ins = new IFNONNULL(generateLabel(r, code));
-                break;
-            case Const.GOTO_W:
-                ins = new GOTO_W(generateLabel(r, code));
-                break;
-            default:
-                throw new AssumptionViolatedException("Invalid opcode");
-
-        }
-        return ins;
+    static void setVersion(SourceOfRandomness random, ClassGen clazz) {
+        random.choose(versionList).accept(clazz);
     }
 
-    InstructionHandle generateLabel(SourceOfRandomness r, InstructionList code) {
-        InstructionHandle handles[] = code.getInstructionHandles();
-        // If no instructions generated so far, emit a NOP to get some label
-        if (handles.length == 0) {
-            handles = new InstructionHandle[]{ code.append(new NOP()) };
-        }
-        return r.choose(handles);
-    }
-
-    String generateClassName(SourceOfRandomness r)
-    {
-        if (r.nextBoolean()) {
-            return r.choose(interestingClasses);
-        }
-        int numParts = r.nextInt(1, 5);
-        String[] parts = new String[numParts];
-        for (int i = 0; i < numParts; i++) {
-            parts[i] = generateMemberName(r);
-        }
-        return String.join("/", parts);
-    }
-
-    int generateFieldRef(SourceOfRandomness r) {
-        String sig = "()" + generateTypeSignature(r, true);
-        return constants.addFieldref(generateClassName(r), generateMemberName(r), sig);
-    }
-
-    int generateMethodRef(SourceOfRandomness r) {
-        int numParams = r.nextInt(4);
-        String sig = "(";
-        for (int i = 0; i < numParams; i++) {
-            sig += generateTypeSignature(r, true);
-        }
-        sig += ")";
-        sig += generateTypeSignature(r, true);
-        return constants.addMethodref(generateClassName(r), generateMemberName(r), sig);
-    }
-
-    int generateClassRef(SourceOfRandomness r) {
-        return constants.addClass(generateClassName(r));
+    static void setVersion(ClassGen clazz, int major, int minor) {
+        clazz.setMajor(major);
+        clazz.setMinor(minor);
     }
 }
+
+

--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/JavaClassNameGenerator.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/JavaClassNameGenerator.java
@@ -1,0 +1,39 @@
+package edu.berkeley.cs.jqf.examples.bcel;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class JavaClassNameGenerator extends Generator<String> {
+    private static final String[] BASIC_CLASS_NAMES = {"java/lang/Object",
+            "java/util/List",
+            "java/util/Map",
+            "java/lang/String",
+            "example/A",
+            "example/B",
+            "java/lang/Throwable",
+            "java/lang/RuntimeException"};
+    private final Generator<String> identifierGenerator = new JavaIdentifierGenerator();
+    private final String delimiter;
+
+    public JavaClassNameGenerator() {
+        this("/");
+    }
+
+    public JavaClassNameGenerator(String delimiter) {
+        super(String.class);
+        this.delimiter = delimiter;
+    }
+
+    @Override
+    public String generate(SourceOfRandomness random, GenerationStatus status) {
+        if (random.nextBoolean()) {
+            return random.choose(BASIC_CLASS_NAMES);
+        }
+        String[] parts = new String[random.nextInt(1, 5)];
+        for (int i = 0; i < parts.length; i++) {
+            parts[i] = identifierGenerator.generate(random, status);
+        }
+        return String.join(delimiter, parts);
+    }
+}

--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/JavaIdentifierGenerator.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/JavaIdentifierGenerator.java
@@ -1,0 +1,68 @@
+package edu.berkeley.cs.jqf.examples.bcel;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Size;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+import static com.pholser.junit.quickcheck.internal.Ranges.Type.INTEGRAL;
+import static com.pholser.junit.quickcheck.internal.Ranges.checkRange;
+
+public final class JavaIdentifierGenerator extends Generator<String> {
+    private static final char MIN_VALID_CHAR = '$';
+    private static final char MAX_VALID_CHAR = 'z';
+    private int minSize = 1;
+    private int maxSize = 30;
+
+    public JavaIdentifierGenerator() {
+        super(String.class);
+    }
+
+    @Override
+    public String generate(SourceOfRandomness random, GenerationStatus status) {
+        return generate(random);
+    }
+
+    @SuppressWarnings("unused")
+    public void configure(Size size) {
+        if (size.min() <= 0) {
+            throw new IllegalArgumentException("Minimum size must be positive");
+        }
+        checkRange(INTEGRAL, size.min(), size.max());
+        minSize = size.min();
+        maxSize = size.max();
+    }
+
+    public String generate(SourceOfRandomness random) {
+        int size = random.nextInt(minSize, maxSize);
+        char[] values = new char[size];
+        values[0] = generateJavaIdentifierStart(random);
+        for (int i = 1; i < values.length; i++) {
+            values[i] = generateJavaIdentifierPart(random);
+        }
+        return new String(values);
+    }
+
+    static char generateJavaIdentifierStart(SourceOfRandomness random) {
+        char c = random.nextChar(MIN_VALID_CHAR, MAX_VALID_CHAR);
+        if (!Character.isJavaIdentifierStart(c)) {
+            return mapToAlpha(c);
+        }
+        return c;
+    }
+
+    static char generateJavaIdentifierPart(SourceOfRandomness random) {
+        char c = random.nextChar(MIN_VALID_CHAR, MAX_VALID_CHAR);
+        if (!Character.isJavaIdentifierPart(c)) {
+            return mapToAlpha(c);
+        }
+        return c;
+    }
+
+    static char mapToAlpha(char c) {
+        char min = 'a';
+        char max = 'z';
+        int range = max - min + 1;
+        return (char) ((c % range) + min);
+    }
+}

--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/MethodGenerator.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/MethodGenerator.java
@@ -1,0 +1,254 @@
+package edu.berkeley.cs.jqf.examples.bcel;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Method;
+import org.apache.bcel.generic.*;
+import org.junit.AssumptionViolatedException;
+
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class MethodGenerator {
+    private static final int MIN_ARGUMENTS = 0;
+    private static final int MAX_ARGUMENTS = 10;
+    private static final int MAX_INSTRUCTIONS = 100;
+    private static final int MIN_INSTRUCTIONS = 0;
+    private static final int MAX_SWITCH_KEYS = 10;
+    private final Supplier<String> classNameSupplier;
+    private final Supplier<String> identifierSupplier;
+    private final TypeGenerator typeGenerator;
+    private final SourceOfRandomness random;
+    private final ClassGen clazz;
+
+    MethodGenerator(SourceOfRandomness random, GenerationStatus status, ClassGen clazz) {
+        this.random = random;
+        this.clazz = clazz;
+        Generator<String> classNameGenerator = new JavaClassNameGenerator();
+        Generator<String> identifierGenerator = new JavaIdentifierGenerator();
+        this.typeGenerator = new TypeGenerator(random, status);
+        this.classNameSupplier = () -> classNameGenerator.generate(random, status);
+        this.identifierSupplier = () -> identifierGenerator.generate(random, status);
+    }
+
+    public Method generate() {
+        String methodName = identifierSupplier.get();
+        Type returnType = random.nextBoolean() ? Type.VOID : typeGenerator.generate();
+        int numberOfArguments = random.nextInt(MIN_ARGUMENTS, MAX_ARGUMENTS);
+        Type[] argumentTypes = Stream.generate(typeGenerator::generate).limit(numberOfArguments).toArray(Type[]::new);
+        String[] argumentNames = Stream.generate(identifierSupplier).limit(numberOfArguments).toArray(String[]::new);
+        InstructionFactory factory = new InstructionFactory(clazz);
+        InstructionList code = generateInstructions(factory, argumentTypes);
+        short accessFlags = random.nextShort((short) 0, Short.MAX_VALUE);
+        MethodGen method = new MethodGen(accessFlags,
+                returnType,
+                argumentTypes,
+                argumentNames,
+                methodName,
+                clazz.getClassName(),
+                code,
+                clazz.getConstantPool());
+        return method.getMethod();
+    }
+
+    private InstructionList generateInstructions(InstructionFactory factory, Type[] argumentTypes) {
+        InstructionList instructionList = new InstructionList();
+        int numberOfInstructions = random.nextInt(MIN_INSTRUCTIONS, MAX_INSTRUCTIONS);
+        int maxLocals = random.nextInt(argumentTypes.length + 1, 2 * argumentTypes.length + 1);
+        while (instructionList.size() < numberOfInstructions) {
+            Instruction ins = generateInstruction(factory, maxLocals, instructionList);
+            if (ins instanceof BranchInstruction) {
+                instructionList.append((BranchInstruction) ins);
+            } else {
+                instructionList.append(ins);
+            }
+        }
+        return instructionList;
+    }
+
+    private Instruction generateInstruction(InstructionFactory factory, int maxLocals,
+                                            InstructionList instructionList) {
+        short opcode = random.nextShort(Const.NOP, Const.BREAKPOINT);
+        Instruction ins = InstructionConst.getInstruction(opcode);
+        if (ins != null) {
+            return ins; // Used predefined immutable object, if available
+        }
+        switch (opcode) {
+            case Const.BIPUSH:
+                return factory.createConstant(random.nextByte(Byte.MIN_VALUE, Byte.MAX_VALUE));
+            case Const.SIPUSH:
+                return factory.createConstant(random.nextShort(Short.MIN_VALUE, Short.MAX_VALUE));
+            case Const.LDC:
+            case Const.LDC_W:
+                return factory.createConstant("?");
+            case Const.LDC2_W:
+                return factory.createConstant(random.nextDouble(Double.MIN_VALUE, Double.MAX_VALUE));
+            case Const.ILOAD:
+                return new ILOAD(random.nextInt(maxLocals));
+            case Const.LLOAD:
+                return new LLOAD(random.nextInt(maxLocals));
+            case Const.FLOAD:
+                return new FLOAD(random.nextInt(maxLocals));
+            case Const.DLOAD:
+                return new DLOAD(random.nextInt(maxLocals));
+            case Const.ALOAD:
+                return new ALOAD(random.nextInt(maxLocals));
+            case Const.ILOAD_0:
+            case Const.ILOAD_1:
+            case Const.ILOAD_2:
+            case Const.ILOAD_3:
+                return new ILOAD(opcode - Const.ILOAD_0);
+            case Const.LLOAD_0:
+            case Const.LLOAD_1:
+            case Const.LLOAD_2:
+            case Const.LLOAD_3:
+                return new LLOAD(opcode - Const.LLOAD_0);
+            case Const.FLOAD_0:
+            case Const.FLOAD_1:
+            case Const.FLOAD_2:
+            case Const.FLOAD_3:
+                return new FLOAD(opcode - Const.FLOAD_0);
+            case Const.DLOAD_0:
+            case Const.DLOAD_1:
+            case Const.DLOAD_2:
+            case Const.DLOAD_3:
+                return new DLOAD(opcode - Const.DLOAD_0);
+            case Const.ALOAD_0:
+            case Const.ALOAD_1:
+            case Const.ALOAD_2:
+            case Const.ALOAD_3:
+                return new ALOAD(opcode - Const.ALOAD_0);
+            case Const.ISTORE:
+                return new ISTORE(random.nextInt(maxLocals));
+            case Const.LSTORE:
+                return new LSTORE(random.nextInt(maxLocals));
+            case Const.FSTORE:
+                return new FSTORE(random.nextInt(maxLocals));
+            case Const.DSTORE:
+                return new DSTORE(random.nextInt(maxLocals));
+            case Const.ASTORE:
+                return new ASTORE(random.nextInt(maxLocals));
+            case Const.ISTORE_0:
+            case Const.ISTORE_1:
+            case Const.ISTORE_2:
+            case Const.ISTORE_3:
+                return new ISTORE(opcode - Const.ISTORE_0);
+            case Const.LSTORE_0:
+            case Const.LSTORE_1:
+            case Const.LSTORE_2:
+            case Const.LSTORE_3:
+                return new LSTORE(opcode - Const.LSTORE_0);
+            case Const.FSTORE_0:
+            case Const.FSTORE_1:
+            case Const.FSTORE_2:
+            case Const.FSTORE_3:
+                return new FSTORE(opcode - Const.FSTORE_0);
+            case Const.DSTORE_0:
+            case Const.DSTORE_1:
+            case Const.DSTORE_2:
+            case Const.DSTORE_3:
+                return new DSTORE(opcode - Const.DSTORE_0);
+            case Const.ASTORE_0:
+            case Const.ASTORE_1:
+            case Const.ASTORE_2:
+            case Const.ASTORE_3:
+                return new ASTORE(opcode - Const.ASTORE_0);
+            case Const.IINC:
+                return new IINC(random.nextInt(maxLocals), random.nextInt(-128, 128));
+            case Const.GETSTATIC:
+            case Const.PUTSTATIC:
+            case Const.GETFIELD:
+            case Const.PUTFIELD:
+                return generateFieldAccess(factory, opcode);
+            case Const.INVOKEVIRTUAL:
+            case Const.INVOKESPECIAL:
+            case Const.INVOKESTATIC:
+            case Const.INVOKEINTERFACE:
+            case Const.INVOKEDYNAMIC:
+                return generateInvoke(factory, opcode);
+            case Const.NEW:
+                return factory.createNew(typeGenerator.generateObjectType());
+            case Const.CHECKCAST:
+                return factory.createCast(typeGenerator.generateReferenceType(), typeGenerator.generateReferenceType());
+            case Const.INSTANCEOF:
+                return factory.createInstanceOf(typeGenerator.generateReferenceType());
+            case Const.NEWARRAY:
+            case Const.ANEWARRAY:
+            case Const.MULTIANEWARRAY:
+                return factory.createNewArray(typeGenerator.generate(), random.nextShort((short) 1, (short) 20));
+            case Const.IFEQ:
+            case Const.IFNE:
+            case Const.IFLT:
+            case Const.IFGE:
+            case Const.IFGT:
+            case Const.IFLE:
+            case Const.IF_ICMPEQ:
+            case Const.IF_ICMPNE:
+            case Const.IF_ICMPLT:
+            case Const.IF_ICMPGE:
+            case Const.IF_ICMPGT:
+            case Const.IF_ICMPLE:
+            case Const.IF_ACMPEQ:
+            case Const.IF_ACMPNE:
+            case Const.GOTO:
+            case Const.JSR:
+            case Const.IFNULL:
+            case Const.IFNONNULL:
+            case Const.GOTO_W:
+            case Const.JSR_W:
+                return InstructionFactory.createBranchInstruction(opcode, chooseTarget(instructionList));
+            case Const.RET:
+                return new RET(random.nextInt(maxLocals));
+            case Const.TABLESWITCH:
+            case Const.LOOKUPSWITCH:
+                return generateSwitch(opcode, instructionList);
+            case Const.WIDE:
+            case Const.BREAKPOINT:
+                return new BREAKPOINT();
+            default:
+                throw new AssumptionViolatedException("Invalid opcode");
+        }
+    }
+
+    private InvokeInstruction generateInvoke(InstructionFactory factory, short opcode) {
+        String className = classNameSupplier.get();
+        String name = identifierSupplier.get();
+        Type returnType = random.nextBoolean() ? Type.VOID : typeGenerator.generate();
+        int numberOfArguments = random.nextInt(MIN_ARGUMENTS, MAX_ARGUMENTS);
+        Type[] argumentTypes = Stream.generate(typeGenerator::generate).limit(numberOfArguments).toArray(Type[]::new);
+        return factory.createInvoke(className, name, returnType, argumentTypes, opcode);
+    }
+
+    private InstructionHandle chooseTarget(InstructionList instructionList) {
+        InstructionHandle[] handles = instructionList.getInstructionHandles();
+        // If no instructions generated so far, emit a NOP to get some label
+        if (handles.length == 0) {
+            handles = new InstructionHandle[]{instructionList.append(new NOP())};
+        }
+        return random.choose(handles);
+    }
+
+    private Select generateSwitch(int opcode, InstructionList instructionList) {
+        int[] matches = IntStream.generate(random::nextInt)
+                .limit(random.nextInt(0, MAX_SWITCH_KEYS))
+                .distinct()
+                .sorted()
+                .toArray();
+        InstructionHandle[] targets = Stream.generate(() -> chooseTarget(instructionList))
+                .limit(matches.length)
+                .toArray(InstructionHandle[]::new);
+        InstructionHandle defaultTarget = chooseTarget(instructionList);
+        return opcode == Const.TABLESWITCH ? new TABLESWITCH(matches, targets, defaultTarget) :
+                new LOOKUPSWITCH(matches, targets, defaultTarget);
+    }
+
+    private FieldInstruction generateFieldAccess(InstructionFactory factory, short opcode) {
+        return factory.createFieldAccess(classNameSupplier.get(),
+                identifierSupplier.get(),
+                typeGenerator.generate(),
+                opcode);
+    }
+}

--- a/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/TypeGenerator.java
+++ b/examples/src/test/java/edu/berkeley/cs/jqf/examples/bcel/TypeGenerator.java
@@ -1,0 +1,56 @@
+package edu.berkeley.cs.jqf.examples.bcel;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+import org.apache.bcel.generic.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TypeGenerator {
+    private final List<ObjectType> COMMON_TYPES =
+            Arrays.asList(Type.OBJECT, Type.CLASS, Type.STRING, Type.STRINGBUFFER, Type.THROWABLE);
+    private final List<BasicType> PRIMITIVE_TYPES =
+            Arrays.asList(Type.BOOLEAN, Type.INT, Type.SHORT, Type.BYTE, Type.LONG, Type.DOUBLE, Type.FLOAT, Type.CHAR);
+    private final Generator<String> classNameGenerator = new JavaClassNameGenerator("/");
+    private final SourceOfRandomness random;
+    private final GenerationStatus status;
+
+    public TypeGenerator(SourceOfRandomness random, GenerationStatus status) {
+        this.random = random;
+        this.status = status;
+    }
+
+    public Type generate() {
+        switch (random.nextInt(3)) {
+            case 0:
+                return generateArrayType();
+            case 1:
+                return generateObjectType();
+            default:
+                return generatePrimitiveType();
+        }
+    }
+
+    public BasicType generatePrimitiveType() {
+        return random.choose(PRIMITIVE_TYPES);
+    }
+
+    public ArrayType generateArrayType() {
+        Type type = random.nextBoolean() ? generatePrimitiveType() : generateObjectType();
+        return new ArrayType(type, random.nextInt(1, 10));
+    }
+
+    public ObjectType generateObjectType() {
+        if (random.nextBoolean()) {
+            return random.choose(COMMON_TYPES);
+        } else {
+            return new ObjectType(classNameGenerator.generate(random, status));
+        }
+    }
+
+    public ReferenceType generateReferenceType() {
+        return random.nextBoolean() ? generateArrayType() : generateObjectType();
+    }
+}


### PR DESCRIPTION
I made the following changes to ` JavaClassGenerator` to improve its ability to exercise functionality in BCEL:
* Class names are now randomly generated. Previously they were always "example.A".
* Super class names are now randomly generated. Previously, they were always either "example.B" or "java.lang.Object".
* Class access flags are now set in accordance with the Java Virtual Machine Specification.
* Class versions are now randomly selected. Previously, they were left as the default of Java 1.1.
* Interface names are now randomly generated. Previously, they were of the form "example.I" followed by an index.
* Field access flags are now set in accordance with the Java Virtual Machine Specification.
* Field visibility is now chosen at random.
* When appropriate, initial field values are now randomly generated.
* Changed how identifiers (member names) are generated to allow additional valid characters.
* Improved instruction generation to support additional instructions

	To evaluation these changes, I ran twenty fuzzing campaigns each lasting 3-hours using the current implementation of JavaClassGenerator and the implementation proposed in this pull request. Branch coverage was measured for each campaign using JaCoCo (version 0.8.7) by rerunning inputs saved to the corpus and failures directory in a new JVM after the campaign finished. Only in application classes (classes from Apache Commons BCEL version 6.2) were included in coverage measurements.

	The number of branches covered on 3-hours campaigns was significantly greater for the proposed implementation compared to the current implementation (Mann-Whitney U = 400.0, P = 0.0000 two-tailed) with a large effect size (Vargha-Delaney Â₁₂ = 1.0). Median branch coverage for the proposed and current implementations were 1691 and 1383.5, respectively. The attached figure plots the median number of covered branches (solid line) the range of covered branches (filled area) across the 20 trials over the duration of the fuzzing campaign for each of implementations.

![coverage](https://user-images.githubusercontent.com/32645020/236892298-fda12a3b-10c7-4da9-ad05-f032cd441c8d.png)