### PR TITLE
Tyche logging support

### DIFF
--- a/fuzz/pom.xml
+++ b/fuzz/pom.xml
@@ -55,6 +55,12 @@
             <artifactId>eclipse-collections</artifactId>
             <version>10.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/afl/AFLGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/afl/AFLGuidance.java
@@ -167,6 +167,11 @@ public class AFLGuidance implements Guidance {
         }
     }
 
+    @Override
+    public String observeGuidance() {
+        return "AFL";
+    }
+
 
     /**
      * Returns an input stream containing the bytes that AFL

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
@@ -437,6 +437,14 @@ public class ZestGuidance implements Guidance {
 
     }
 
+    @Override
+    public String observeGuidance() {
+        if (blind) {
+            return "Random";
+        }
+        return "Zest";
+    }
+
     /* Writes a line of text to the log file. */
     protected void infoLog(String str, Object... args) {
         if (verbose) {

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/guidance/Guidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/guidance/Guidance.java
@@ -133,6 +133,14 @@ public interface Guidance {
     }
 
     /**
+     * <p>This method is only invoked during optional observability
+     * logging to provide the type of guidance used for input generation.</p>
+     */
+    default String observeGuidance() {
+        return "";
+    }
+
+    /**
      * Handles the end of a fuzzing trial.
      *
      * <p>This method is guaranteed to be invoked by JQF

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
@@ -186,7 +186,7 @@ public class FuzzStatement extends Statement {
                     if (result == SUCCESS) {
                         observability.addTiming(startTrialTime, endGenerationTime, endTrialTime);
                     }
-                    observability.add("representation", Arrays.toString(args));
+                    observability.addArgs(args);
 
                     if (guidance instanceof ZestGuidance) {
                         observability.add("how_generated", "Zest");

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
@@ -30,21 +30,12 @@
 package edu.berkeley.cs.jqf.fuzz.junit.quickcheck;
 
 import java.io.EOFException;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
 import java.lang.reflect.Parameter;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
 import com.pholser.junit.quickcheck.generator.Generator;
 import com.pholser.junit.quickcheck.internal.ParameterTypeContext;
@@ -127,7 +118,7 @@ public class FuzzStatement extends Statement {
                 long startTrialTime = System.currentTimeMillis();
 
                 // Initialize guided fuzzing using a file-backed random number source
-                Object [] args = null;
+                Object [] args = {};
                 try {
                     try {
 
@@ -191,17 +182,12 @@ public class FuzzStatement extends Statement {
                 }
                 long endTrialTime = System.currentTimeMillis();
                 if (System.getProperty("jqfObservability") != null) {
-
-
-                    // - "status": "passed", "failed", or "gave_up"
                     observability.addStatus(result);
                     if (result == SUCCESS) {
                         observability.addTiming(startTrialTime, endGenerationTime, endTrialTime);
                     }
                     observability.add("representation", Arrays.toString(args));
-                    // - "status_reason": If non-empty, the reason for which the test failed or was abandoned.
 
-                    // - "how_generated": "Zest", "blind", or "repro"
                     if (guidance instanceof ZestGuidance) {
                         observability.add("how_generated", "Zest");
                     } else if (guidance instanceof NoGuidance) {
@@ -213,8 +199,6 @@ public class FuzzStatement extends Statement {
                     }
 
                     observability.writeToFile();
-
-
                 }
 
                 // Inform guidance about the outcome of this trial

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/junit/quickcheck/FuzzStatement.java
@@ -187,16 +187,7 @@ public class FuzzStatement extends Statement {
                         observability.addTiming(startTrialTime, endGenerationTime, endTrialTime);
                     }
                     observability.addArgs(args);
-
-                    if (guidance instanceof ZestGuidance) {
-                        observability.add("how_generated", "Zest");
-                    } else if (guidance instanceof NoGuidance) {
-                        observability.add("how_generated", "random");
-                    } else if (guidance instanceof ReproGuidance) {
-                        observability.add("how_generated", "repro");
-                    } else {
-                        observability.add("how_generated", "unknown");
-                    }
+                    observability.add("how_generated", guidance.observeGuidance());
 
                     observability.writeToFile();
                 }

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/repro/ReproGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/repro/ReproGuidance.java
@@ -191,6 +191,11 @@ public class ReproGuidance implements Guidance {
         }
     }
 
+    @Override
+    public String observeGuidance() {
+        return "Repro";
+    }
+
     /**
      * Writes an object to a file
      *

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/Observability.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/Observability.java
@@ -8,6 +8,7 @@ import edu.berkeley.cs.jqf.fuzz.guidance.Result;
 import java.io.FileWriter;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 
 import static edu.berkeley.cs.jqf.fuzz.guidance.Result.FAILURE;
 import static edu.berkeley.cs.jqf.fuzz.guidance.Result.INVALID;
@@ -79,6 +80,15 @@ public class Observability {
         ObjectNode timingObject = (ObjectNode) timingNode;
         timingObject.put("generation", endGenerationTime - startTime);
         timingObject.put("execution", endExecutionTime - endGenerationTime);
+    }
+
+    public void addArgs(Object[] args) {
+        JsonNode argsNode = testCaseJsonObject.get("args");
+        ObjectNode argsObject = (ObjectNode) argsNode;
+        for (int i = 0; i < args.length; i++) {
+            argsObject.put("arg" + i, args[i].toString());
+        }
+        add("representation", Arrays.toString(args));
     }
 
     public void add(String key, String value) {

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/Observability.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/util/Observability.java
@@ -1,0 +1,100 @@
+package edu.berkeley.cs.jqf.fuzz.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import edu.berkeley.cs.jqf.fuzz.guidance.Result;
+
+import java.io.FileWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static edu.berkeley.cs.jqf.fuzz.guidance.Result.FAILURE;
+import static edu.berkeley.cs.jqf.fuzz.guidance.Result.INVALID;
+
+public class Observability {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final String testClass;
+    private final String testMethod;
+    private final Path obsPath;
+    private static ObjectNode testCaseJsonObject;
+    private final long startTime;
+
+    public Observability(String testClass, String testMethod, long startTime) {
+        this.testClass = testClass;
+        this.testMethod = testMethod;
+        this.obsPath = Paths.get("target", "fuzz-results", testClass, testMethod, "observations.jsonl");
+        if (obsPath.toFile().exists()) {
+            obsPath.toFile().delete();
+        }
+        this.startTime = startTime;
+        this.initializeTestCase();
+    }
+
+    public void initializeTestCase() {
+        testCaseJsonObject = objectMapper.createObjectNode();
+        testCaseJsonObject.putObject("features");
+        testCaseJsonObject.putObject("timing");
+        testCaseJsonObject.putObject("coverage");
+        testCaseJsonObject.putObject("args");
+        testCaseJsonObject.putObject("metadata");
+        testCaseJsonObject.put("type", "test_case");
+        testCaseJsonObject.put("run_start", startTime);
+        testCaseJsonObject.put("property", testMethod);
+    }
+
+    public static void event(String value, Object payload) throws RuntimeException {
+        // Add the payload to the features object
+        JsonNode jsonFeaturesNode = testCaseJsonObject.get("features");
+        ObjectNode featuresNode = (ObjectNode) jsonFeaturesNode;
+
+        if (payload instanceof Integer) {
+            featuresNode.put(value, (Integer) payload);
+        } else if (payload instanceof String) {
+            featuresNode.put(value, (String) payload);
+        } else if (payload instanceof Float) {
+            featuresNode.put(value, (Float) payload);
+        } else {
+            throw new RuntimeException("Unsupported payload type for event");
+        }
+    }
+
+    public void addStatus(Result result) {
+        if (result == INVALID) {
+            testCaseJsonObject.put("status", "gave_up");
+            testCaseJsonObject.put("status_reason", "assumption violated");
+        } else if (result == FAILURE) {
+            testCaseJsonObject.put("status", "failed");
+            testCaseJsonObject.put("status_reason", "Encountered exception");
+        } else {
+            testCaseJsonObject.put("status", "passed");
+            testCaseJsonObject.put("status_reason", "");
+        }
+
+    }
+
+    public void addTiming(long startTime, long endGenerationTime, long endExecutionTime) {
+        JsonNode timingNode = testCaseJsonObject.get("timing");
+        ObjectNode timingObject = (ObjectNode) timingNode;
+        timingObject.put("generation", endGenerationTime - startTime);
+        timingObject.put("execution", endExecutionTime - endGenerationTime);
+    }
+
+    public void add(String key, String value) {
+        testCaseJsonObject.put(key, value);
+    }
+
+    public void writeToFile() {
+        // Append the JSON object to a file followed by a newline
+        try {
+            String jsonString = objectMapper.writeValueAsString(testCaseJsonObject);
+            try (FileWriter writer = new FileWriter(obsPath.toFile(), true)) {
+                writer.write(jsonString);
+                writer.write(System.lineSeparator()); // Add a new line after each object
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write observations to file", e);
+        }
+    }
+}


### PR DESCRIPTION
Resolves #257 

Logging support for Tyche (feature flag enabled by `-DjqfObservability`). The output file will be `target/fuzz-results/TEST_CLASS/TEST_METHOD/observations.jsonl`.

Modifies `FuzzStatement` to add logging at the end of the guidance loop if the flag is enabled. Adds the `fuzz.util.Observability.event` method that can be invoked in the fuzz target to log specific input features. Per-input coverage still not yet implemented. Since the coverage data in Tyche is per-input line coverage for each file, this should be done as a post processing step.

Example fuzz target (for ChocoPy):
```
@Fuzz
public void fuzzSemanticAnalysis(@From(ChocoPySemanticGeneratorTypeDirected.class) String code) {
    Program program = RefParser.process(code, false);
    assumeTrue(!program.hasErrors());
    event("numStatements", program.statements.size());
    event("numDeclarations", program.declarations.size());
    Program typedProgram = RefAnalysis.process(program);
    event("numErrors", program.getErrorList().size());
    assumeTrue(!typedProgram.hasErrors());
}
```
Example visualization:
![image](https://github.com/user-attachments/assets/aeebea99-f3f5-41af-bead-5db5c93835db)
