### PR TITLE
fix: save all inputs with `saveAll` flag

### DIFF
--- a/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
+++ b/maven-plugin/src/main/java/edu/berkeley/cs/jqf/plugin/FuzzGoal.java
@@ -304,7 +304,7 @@ public class FuzzGoal extends AbstractMojo {
 
         // Configure Zest Guidance
         if (saveAll) {
-            System.setProperty("jqf.ei.SAVE_ALL_INPUTS", "true");
+            System.setProperty("jqf.ei.LOG_ALL_INPUTS", "true");
         }
         if (libFuzzerCompatOutput != null) {
             System.setProperty("jqf.ei.LIBFUZZER_COMPAT_OUTPUT", libFuzzerCompatOutput);


### PR DESCRIPTION
The property being used to identify if all inputs must be saved is `LOG_ALL_INPUTS`. `SAVE_ALL_INPUTS` seems to be an artifact from an older commit that was not changed.