### PR TITLE
pom: Fix license name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <url>https://github.com/rohanpadhye/jqf</url>
     <licenses>
         <license>
-            <name>FreeBSD License</name>
+            <name>BSD-2-Clause</name>
             <url>https://opensource.org/licenses/BSD-2-Clause</url>
         </license>
     </licenses>


### PR DESCRIPTION
Fix up license metadata in parent pom as LICENSE file[1] of JQF project matches the BSD-2-Clause[2] license text and not FreeBSD or BSD-2-Clause-FreeBSD[3].

[1]: https://github.com/rohanpadhye/JQF/blob/jqf-2.0/LICENSE
[2]: https://spdx.org/licenses/BSD-2-Clause.html
[3]: https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html