### PR TITLE
Make Current Input Logging Conditional for Better Performance

### DIFF
--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
@@ -216,8 +216,8 @@ public class ZestGuidance implements Guidance {
     /** Whether to store all generated inputs to disk (can get slowww!) */
     protected final boolean LOG_ALL_INPUTS = Boolean.getBoolean("jqf.ei.LOG_ALL_INPUTS");
 
-    /** Whether to update .cur_input file with most recently generated input (enabling it will negatively impact performance) */
-    protected final boolean LOG_CURRENT_INPUT = Boolean.getBoolean("jqf.ei.LOG_CURRENT_INPUT");
+    /** Controls whether to update the .cur_input file with the most recently generated input (disabling improves performance). Defaults to true. */
+    protected final boolean LOG_CURRENT_INPUT = Boolean.parseBoolean(System.getProperty("jqf.ei.LOG_CURRENT_INPUT", "true"));
 
     // ------------- TIMEOUT HANDLING ------------
 

--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/ei/ZestGuidance.java
@@ -216,6 +216,9 @@ public class ZestGuidance implements Guidance {
     /** Whether to store all generated inputs to disk (can get slowww!) */
     protected final boolean LOG_ALL_INPUTS = Boolean.getBoolean("jqf.ei.LOG_ALL_INPUTS");
 
+    /** Whether to update .cur_input file with most recently generated input (enabling it will negatively impact performance) */
+    protected final boolean LOG_CURRENT_INPUT = Boolean.getBoolean("jqf.ei.LOG_CURRENT_INPUT");
+
     // ------------- TIMEOUT HANDLING ------------
 
     /** Timeout for an individual run. */
@@ -710,10 +713,12 @@ public class ZestGuidance implements Guidance {
                 currentInput = parent.fuzz(random);
                 numChildrenGeneratedForCurrentParentInput++;
 
-                // Write it to disk for debugging
-                try {
-                    writeCurrentInputToFile(currentInputFile);
-                } catch (IOException ignore) {
+                // Write current input to disk for debugging
+                if (LOG_CURRENT_INPUT) {
+                    try {
+                        writeCurrentInputToFile(currentInputFile);
+                    } catch (IOException ignore) {
+                    }
                 }
 
                 // Start time-counting for timeout handling


### PR DESCRIPTION
## Overview
This change improves ZestGuidance performance by making current input file logging optional. In one of our projects, disabling this logging resulted in more than a 2x increase in tests per minute.

## Problem
ZestGuidance was unconditionally saving the current input to a `.cur_input` file on every test iteration, causing unnecessary file I/O overhead.

## Solution
Added a configurable ``jqf.ei.LOG_CURRENT_INPUT`` flag that is enabled by default to maintain backwards compatibility. 