### PR TITLE
build: compile with JDK 25 and target Java 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2
+    - uses: actions/checkout@v4
+    - name: Set up JDK 25
+      uses: actions/setup-java@v4
       with:
-        java-version: '11'
-        distribution: 'adopt'
+        java-version: '25'
+        distribution: 'temurin'
     - name: Cache Maven dependencies
       uses: actions/cache@v4
       with:

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -47,8 +47,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <release>11</release>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.14.0</version>
                     <configuration>
-                        <release>9</release>
+                        <release>11</release>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## Why

The project builds on JDK 11 and targets `release 9`. Two problems: Java 9 and 10 are long past EOL, so there is no reason to keep 9 as the release floor; and building on an old JDK means missing later javac fixes. This moves the build to the latest JDK while lowering the risk surface of the compiler, and raises the target to Java 11 (LTS).

## What

- `pom.xml`: `maven-compiler-plugin` release `9` → `11`.
- `integration-tests/pom.xml`: replace `<source>11</source>/<target>11</target>` with `<release>11</release>` to match the parent and drop the redundant split configuration.
- `.github/workflows/ci.yml`: build JDK `11` → `25`; distribution `adopt` → `temurin`, since `adopt` (AdoptOpenJDK) has no builds beyond Java 16.
- `.github/workflows/ci.yml`: bump `actions/checkout` and `actions/setup-java` from `v2` to `v4` (v2 runs on a deprecated Node runtime).

The project has no `module-info.java`, so `release 9` was only a low target — raising it to 11 changes nothing structurally. ASM was already bumped to 9.8 for Java 25 support in an earlier commit.

## How to verify

Compiled locally with JDK 25:

- `mvn -B clean compile` succeeds across all modules.
- `mvn -B -P continuous-integration -pl integration-tests -am test-compile` succeeds.
- Emitted bytecode is Java 11 (`javap -v` reports `major version: 55`), including the integration-tests module.

CI runs `mvn -B verify -P continuous-integration` on JDK 25.

## Notes for reviewers

One related item left out of scope, happy to fold in on request: `.github/workflows/apidocs.yml` sets up no JDK (it uses the runner default) and still pins `checkout@v2`/`cache@v2`. That is a separate JavaDoc-deploy workflow, untouched here.