### PR TITLE
perf(fuzz): draw only the bytes each bound needs in StreamBackedRandom.nextInt

### DIFF
--- a/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/guidance/StreamBackedRandom.java
+++ b/fuzz/src/main/java/edu/berkeley/cs/jqf/fuzz/guidance/StreamBackedRandom.java
@@ -152,10 +152,40 @@ public class StreamBackedRandom extends Random {
 
     }
 
+    /**
+     * Returns a pseudo-random value in the range <code>[0, bound)</code>,
+     * consuming only as many whole bytes of the backing source as the bound
+     * requires.
+     *
+     * <p>The original implementation always drew four bytes via
+     * {@link #next(int) next(31)}. For a small bound such as a byte or boolean
+     * range that wasted three of every four input bytes: the surplus bytes are
+     * read and then discarded by the modulo, so mutating them cannot change the
+     * result. Reading <code>ceil(log2(bound))</code> bits rounded up to whole
+     * bytes keeps every consumed byte meaningful and shortens the input a
+     * mutation-based fuzzer has to explore.</p>
+     *
+     * @param bound the exclusive upper bound; must be positive
+     * @return a value in <code>[0, bound)</code>
+     * @throws IllegalArgumentException if <code>bound</code> is not positive
+     */
     @Override
     public int nextInt(int bound) {
         if (bound <= 0)
             throw new IllegalArgumentException("bound must be positive");
+        // A bound of one always maps to zero, so no input needs to be consumed.
+        if (bound == 1) {
+            return 0;
+        }
+        // Number of significant bits in bound - 1, i.e. ceil(log2(bound)).
+        int significantBits = 32 - Integer.numberOfLeadingZeros(bound - 1);
+        if (significantBits <= 24) {
+            // Round up to whole bytes: 1 byte for bound <= 256, 2 for <= 65536, 3 for <= 2^24.
+            int bitsToRead = ((significantBits + 7) / 8) * 8;
+            return next(bitsToRead) % bound;
+        }
+        // For very large bounds fall back to four bytes. next(31) stays
+        // non-negative (unlike next(32)), so the modulo is well defined.
         return next(31) % bound;
     }
 

--- a/fuzz/src/test/java/edu/berkeley/cs/jqf/fuzz/guidance/StreamBackedRandomTest.java
+++ b/fuzz/src/test/java/edu/berkeley/cs/jqf/fuzz/guidance/StreamBackedRandomTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Vladimir Sitnikov and JQF Contributors
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package edu.berkeley.cs.jqf.fuzz.guidance;
+
+import java.io.ByteArrayInputStream;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link StreamBackedRandom#nextInt(int)}, which draws only as many
+ * whole bytes of the backing source as the bound requires.
+ */
+public class StreamBackedRandomTest {
+
+    /** Builds a generator backed by the given bytes (each argument is one unsigned byte). */
+    private static StreamBackedRandom backedBy(int... unsignedBytes) {
+        byte[] bytes = new byte[unsignedBytes.length];
+        for (int i = 0; i < unsignedBytes.length; i++) {
+            bytes[i] = (byte) unsignedBytes[i];
+        }
+        return new StreamBackedRandom(new ByteArrayInputStream(bytes));
+    }
+
+    @Test
+    public void boundOfOneConsumesNoBytes() {
+        // No bytes are available, yet a bound of one must still succeed.
+        StreamBackedRandom random = backedBy();
+        assertEquals(0, random.nextInt(1));
+        assertEquals(0, random.getTotalBytesRead());
+    }
+
+    @Test
+    public void byteRangeConsumesOneByteEach() {
+        // bound = 256 reads a single byte and returns its unsigned value.
+        StreamBackedRandom random = backedBy(0x00, 0x7F, 0x80, 0xFF);
+        assertEquals(0x00, random.nextInt(256));
+        assertEquals(0x7F, random.nextInt(256));
+        assertEquals(0x80, random.nextInt(256));
+        assertEquals(0xFF, random.nextInt(256));
+        assertEquals(4, random.getTotalBytesRead());
+    }
+
+    @Test
+    public void twoByteBoundReadsTwoBytesLittleEndian() {
+        // bound = 2^16 reads exactly two bytes in little-endian order.
+        StreamBackedRandom random = backedBy(0x01, 0x02);
+        assertEquals(0x0201, random.nextInt(1 << 16));
+        assertEquals(2, random.getTotalBytesRead());
+    }
+
+    @Test
+    public void threeByteBoundReadsThreeBytesLittleEndian() {
+        // bound = 2^24 reads exactly three bytes in little-endian order.
+        StreamBackedRandom random = backedBy(0x01, 0x02, 0x03);
+        assertEquals(0x030201, random.nextInt(1 << 24));
+        assertEquals(3, random.getTotalBytesRead());
+    }
+
+    @Test
+    public void consumesMinimalBytesPerBound() {
+        assertBytesConsumed(1, 0);
+        assertBytesConsumed(2, 1);
+        assertBytesConsumed(256, 1);
+        assertBytesConsumed(257, 2);
+        assertBytesConsumed(1 << 16, 2);
+        assertBytesConsumed((1 << 16) + 1, 3);
+        assertBytesConsumed(1 << 24, 3);
+        assertBytesConsumed((1 << 24) + 1, 4);
+        assertBytesConsumed(1 << 30, 4);
+        assertBytesConsumed(Integer.MAX_VALUE, 4);
+    }
+
+    @Test
+    public void singleByteBoundStaysInRangeForEveryByteValue() {
+        // bound = 100 needs seven bits, so one byte is drawn and reduced modulo 100.
+        for (int b = 0; b < 256; b++) {
+            StreamBackedRandom random = backedBy(b);
+            int value = random.nextInt(100);
+            assertTrue("value out of range for byte " + b, value >= 0 && value < 100);
+            assertEquals(b % 100, value);
+            assertEquals(1, random.getTotalBytesRead());
+        }
+    }
+
+    @Test
+    public void largeBoundStaysNonNegative() {
+        // All-ones input makes next(31) return 0x7FFFFFFF, which stays non-negative.
+        StreamBackedRandom random = backedBy(0xFF, 0xFF, 0xFF, 0xFF);
+        int value = random.nextInt(Integer.MAX_VALUE);
+        assertTrue("value must be non-negative", value >= 0);
+        assertEquals(4, random.getTotalBytesRead());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void zeroBoundThrows() {
+        backedBy(1, 2, 3, 4).nextInt(0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeBoundThrows() {
+        backedBy(1, 2, 3, 4).nextInt(-5);
+    }
+
+    /** Draws one value for {@code bound} and asserts the byte count and range. */
+    private static void assertBytesConsumed(int bound, int expectedBytes) {
+        StreamBackedRandom random = new StreamBackedRandom(new ByteArrayInputStream(new byte[8]));
+        int value = random.nextInt(bound);
+        assertTrue("value out of range for bound " + bound, value >= 0 && value < bound);
+        assertEquals("bytes consumed for bound " + bound, expectedBytes, random.getTotalBytesRead());
+    }
+}


### PR DESCRIPTION
## Why

`StreamBackedRandom.nextInt(bound)` always drew four bytes via `next(31)`, regardless of the bound. For a small bound — a byte range, a boolean, an enum — three of every four bytes are read and then thrown away by the modulo, so mutating them cannot change the result. When the bound is a power of two `<= 256`, `next(31) % 256` is just the lowest byte and the other three are pure no-ops. On long arrays (`byte[]`, ASCII text) this inflates the input roughly 4× with bytes a mutation-based fuzzer wastes effort exploring.

## What

`nextInt(bound)` now reads only as many whole bytes as the bound requires — `ceil(log2(bound))` bits rounded up to whole bytes:

| `bound`        | bytes read | was |
|----------------|-----------:|----:|
| 1              | 0          | 4   |
| 2 … 256        | 1          | 4   |
| 257 … 65536    | 2          | 4   |
| 65537 … 2²⁴    | 3          | 4   |
| 2²⁴+1 … 2³¹−1  | 4          | 4   |

Bounds above 2²⁴ keep the four-byte path. That path uses `next(31)`, not `next(32)`: `next(32)` would return a signed `int` and `% bound` could go negative, whereas `next(31)` stays non-negative so the modulo is well defined.

## How to verify

New `StreamBackedRandomTest` (9 tests, all green) covers:

- byte count via `getTotalBytesRead()` for every threshold in the table above;
- little-endian low-byte mapping — `bound=256` returns the low byte; `2¹⁶`/`2²⁴` read 2/3 bytes in LE order;
- range `[0, bound)` across all 256 byte values at `bound=100`;
- non-negativity for large bounds fed all-`0xFF` input;
- `bound <= 0` throws `IllegalArgumentException`.

```
mvn -pl fuzz test -Dtest=StreamBackedRandomTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
```

## Note for reviewers

This changes how existing seed and corpus files map to bounded values (the same bytes now yield different draws) — an unavoidable consequence of the optimisation itself, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)